### PR TITLE
Don't make global labels for rgbasm macros.

### DIFF
--- a/pokemontools/preprocessor.py
+++ b/pokemontools/preprocessor.py
@@ -599,7 +599,7 @@ def read_line(l, macro_table):
     asm, comment = separate_comment(l)
 
     # export all labels
-    if ':' in asm[:asm.find('"')]:
+    if ':' in asm[:asm.find('"')] and "macro" not in asm.lower():
         sys.stdout.write('GLOBAL ' + asm.split(':')[0] + '\n')
 
     # expect preprocessed .asm files


### PR DESCRIPTION
This adds support to the preprocessor to handle constants.asm from
pokered.
