### PR TITLE
Make gfx.py not depend on crystal.py

### DIFF
--- a/pokemontools/gfx.py
+++ b/pokemontools/gfx.py
@@ -5,12 +5,14 @@ import sys
 import png
 from math import sqrt, floor, ceil
 
-import crystal
+import configuration
+config = configuration.Config()
+
 import pokemon_constants
 import trainers
 
 if __name__ != "__main__":
-    rom = crystal.load_rom()
+    rom = romstr.RomStr(filename=config.rom_path)
 
 def hex_dump(input, debug=True):
     """


### PR DESCRIPTION
There's no reason to include crystal.py inside gfx.py, so that import statement has been removed.
