### PR TITLE
Make extract_maps.py Python 3 compatible

### DIFF
--- a/redtools/extract_maps.py
+++ b/redtools/extract_maps.py
@@ -4,6 +4,8 @@
 import json
 import os
 
+from __future__ import print_function
+
 #parse hex values as base 16 (see calculate_pointer)
 base = 16
 


### PR DESCRIPTION
https://docs.python.org/2.7/library/functions.html#print
The print statements are the only reason this script isn't Python 3 compatible. As far as I can tell, it's now compatible from Python 2.6 to 3.4.
