### PR TITLE
Heavily refactor gbz80disasm.py

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Auto detect text files and perform LF normalization
+* text eol=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.py text
+*.txt text
+*.MD text
+*.c text
+*.data text
+*.in text

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,24 @@
 *.gbc
 *.gb
 
+# asm files
+*.asm
+
+# symfile
+*.sym
+
 # generated
 *.tx
+
+# output for some scripts
+*.1bpp
+*.2bpp
+*.png
+*.bst
+*.map
+*.wav
+*.blk
+*.pic
 
 # swap files for vim
 .*.swp


### PR DESCRIPTION
Remove red hardcodes/code hooks, fix issues with label/constant detection, add vram/hram constants, add sram labels, change the way opcodes are read, use str.format to insert arguments, some sort of support for data labels, a lot of additional command line arguments.