### PR TITLE
Python 3 compatibility, sort of, maybe

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Auto detect text files and perform LF normalization
+* text eol=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.py text
+*.txt text
+*.MD text
+*.c text
+*.data text
+*.in text

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,24 @@
 *.gbc
 *.gb
 
+# asm files
+*.asm
+
+# symfile
+*.sym
+
 # generated
 *.tx
+
+# output for some scripts
+*.1bpp
+*.2bpp
+*.png
+*.bst
+*.map
+*.wav
+*.blk
+*.pic
 
 # swap files for vim
 .*.swp

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Run the tests with:
 nosetests-2.7
 ```
 
+There might be a great deal of spammy output. Drop some of the spam with:
+
+```
+nosetests-2.7 tests.integration.tests --nocapture --nologcapture
+```
+
 # see also
 
 * [Pokémon Crystal source code](https://github.com/kanzure/pokecrystal)

--- a/pkmnasm/asmlex.py
+++ b/pkmnasm/asmlex.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import ply.lex as lex
 import sys, os
 
@@ -466,7 +467,7 @@ class Lexer(object):
         ''' Prints an error msg.
         '''
         #print '%s:%i %s' % (FILENAME, self.lex.lineno, str)
-        print '%s:%s %s' % (FILENAME, "?", str)
+        print('%s:%s %s' % (FILENAME, "?", str))
     
     
     def error(self, str):
@@ -490,5 +491,5 @@ if __name__ == '__main__':
     tmp.input(open(sys.argv[1]).read())
     tok = tmp.token()
     while tok:
-        print tok
+        print(tok)
         tok = tmp.token()

--- a/pokemontools/__init__.py
+++ b/pokemontools/__init__.py
@@ -1,6 +1,1 @@
-from __future__ import absolute_import
-from . import configuration as config
-from . import crystal
-from . import preprocessor
-
 __version__ = "1.6.0"

--- a/pokemontools/__init__.py
+++ b/pokemontools/__init__.py
@@ -1,5 +1,6 @@
-import configuration as config
-import crystal
-import preprocessor
+from __future__ import absolute_import
+from . import configuration as config
+from . import crystal
+from . import preprocessor
 
 __version__ = "1.6.0"

--- a/pokemontools/audio.py
+++ b/pokemontools/audio.py
@@ -1,17 +1,18 @@
 # coding: utf-8
 
+from __future__ import absolute_import
 import os
 
 from math import ceil
 
-from song_names import song_names
-from sfx_names import sfx_names
-from cry_names import cry_names
+from .song_names import song_names
+from .sfx_names import sfx_names
+from .cry_names import cry_names
 
-from gbz80disasm import get_global_address, get_local_address
-from labels import line_has_label
-from crystal import music_classes as sound_classes
-from crystal import (
+from .gbz80disasm import get_global_address, get_local_address
+from .labels import line_has_label
+from .crystal import music_classes as sound_classes
+from .crystal import (
     Command,
     SingleByteParam,
     MultiByteParam,
@@ -22,7 +23,7 @@ from crystal import (
 rom = load_rom()
 rom = bytearray(rom)
 
-import configuration
+from . import configuration
 conf = configuration.Config()
 
 
@@ -299,7 +300,7 @@ class Channel:
 				self.address / 0x4000 != self.start_address / 0x4000
 			) and not done:
 				done = True
-				raise Exception, self.label + ': reached the end of the bank without finishing!'
+				raise Exception(self.label + ': reached the end of the bank without finishing!')
 
 		self.output += [(self.address, '; %x\n' % self.address, self.address)]
 

--- a/pokemontools/battle_animations.py
+++ b/pokemontools/battle_animations.py
@@ -1,12 +1,14 @@
 # coding: utf-8
 
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 from new import classobj
 
-import configuration
+from . import configuration
 conf = configuration.Config()
 
-from crystal import (
+from .crystal import (
 	SingleByteParam,
 	PointerLabelParam,
 	DecimalParam,
@@ -15,11 +17,11 @@ from crystal import (
 	load_rom
 )
 
-from gbz80disasm import get_local_address, get_global_address
-from audio import sort_asms
+from .gbz80disasm import get_local_address, get_global_address
+from .audio import sort_asms
 
 
-from wram import read_constants
+from .wram import read_constants
 
 rom = bytearray(load_rom())
 
@@ -42,7 +44,7 @@ anims = read_constants(os.path.join(conf.path, 'constants/animation_constants.as
 objs  = { k: v for k, v in anims.items() if 'ANIM_OBJ' in v }
 bgs   = { k: v for k, v in anims.items() if 'ANIM_BG'  in v }
 anims = { k: v.replace('ANIM_','') for k, v in anims.items() }
-from move_constants import moves
+from .move_constants import moves
 anims.update(moves)
 
 class AnimObjParam(SingleByteParam):
@@ -320,5 +322,5 @@ def asm_list_to_text(asms):
 
 if __name__ == '__main__':
 	asms = dump_battle_anims()
-	print asm_list_to_text(asms)
+	print(asm_list_to_text(asms))
 

--- a/pokemontools/comparator.py
+++ b/pokemontools/comparator.py
@@ -2,8 +2,10 @@
 """
 Find shared functions between red/crystal.
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
-from crystal import (
+from .crystal import (
     get_label_from_line,
     get_address_from_line_comment,
     AsmSection,
@@ -11,7 +13,7 @@ from crystal import (
     direct_load_asm,
 )
 
-from romstr import (
+from .romstr import (
     RomStr,
     AsmList,
 )
@@ -53,7 +55,7 @@ class Address(int):
                 instance = int.__new__(cls, int(x, base=16), *args, **kwargs)
             else:
                 msg = "Address.__new__ doesn't know how to parse this string"
-                raise Exception, msg
+                raise Exception(msg)
         else:
             instance = int.__new__(cls, x, *args, **kwargs)
 
@@ -157,7 +159,7 @@ class BinaryBlob(object):
             found_blobs.append(self)
 
             if self.debug:
-                print self.label + ": found " + str(len(self.locations)) + " matches."
+                print(self.label + ": found " + str(len(self.locations)) + " matches.")
 
     def find_by_first_bytes(self):
         """
@@ -181,7 +183,7 @@ class BinaryBlob(object):
             found_blobs.append(self)
 
             if self.debug:
-                print self.label + ": found " + str(len(self.locations)) + " matches."
+                print(self.label + ": found " + str(len(self.locations)) + " matches.")
 
 pokecrystal_rom_path = "../baserom.gbc"
 pokecrystal_src_path = "../main.asm"
@@ -214,14 +216,14 @@ def scan_red_asm(bank_stop=3, debug=True):
 
     for line in redsrc:
         if debug and show_lines:
-            print "processing a line from red: " + line
+            print("processing a line from red: " + line)
 
         if line[0:7] == "SECTION":
             thing        = AsmSection(line)
             current_bank = thing.bank_id
 
             if debug:
-                print "scan_red_asm: switching to bank " + str(current_bank)
+                print("scan_red_asm: switching to bank " + str(current_bank))
 
         elif line[0:6] != "INCBIN":
             if ":" in line and not ";XXX:" in line and not " ; XXX:" in line:
@@ -240,7 +242,7 @@ def scan_red_asm(bank_stop=3, debug=True):
                                    line_number=line_number)
 
                             if debug:
-                                print "Created a new blob: " + str(blob) + " from line: " + str(latest_line)
+                                print("Created a new blob: " + str(blob) + " from line: " + str(latest_line))
 
                     latest_label          = current_label
                     latest_start_address  = current_start_address
@@ -250,18 +252,18 @@ def scan_red_asm(bank_stop=3, debug=True):
 
         if current_bank == bank_stop:
             if debug:
-                print "scan_red_asm: stopping because current_bank >= " + \
-                      str(bank_stop) + " (bank_stop)"
+                print("scan_red_asm: stopping because current_bank >= " + \
+                      str(bank_stop) + " (bank_stop)")
 
             break
 
 scan_red_asm(bank_stop=3)
 
-print "================================"
+print("================================")
 
 for blob in found_blobs:
-    print blob
+    print(blob)
 
-print "Found " + str(len(found_blobs)) + " possibly copied functions."
+print("Found " + str(len(found_blobs)) + " possibly copied functions.")
 
-print [hex(x) for x in found_blobs[10].locations]
+print([hex(x) for x in found_blobs[10].locations])

--- a/pokemontools/crystal.py
+++ b/pokemontools/crystal.py
@@ -8,12 +8,9 @@ from __future__ import absolute_import
 import os
 import sys
 import inspect
-import hashlib
 import json
 from copy import copy, deepcopy
 import subprocess
-from new import classobj
-import random
 import logging
 
 # for capwords
@@ -1611,7 +1608,7 @@ def create_movement_commands(debug=False):
                 klass_name = cmd_name+"Command"
                 params["id"] = copy(byte)
                 params["macro_name"] = cmd_name
-                klass = classobj(copy(klass_name), (MovementCommand,), deepcopy(params))
+                klass = type(copy(klass_name), (MovementCommand,), deepcopy(params))
                 globals()[klass_name] = klass
                 movement_command_classes2.append(klass)
 
@@ -1621,7 +1618,7 @@ def create_movement_commands(debug=False):
             del klass_name
         else:
             klass_name = cmd_name+"Command"
-            klass = classobj(klass_name, (MovementCommand,), params)
+            klass = type(klass_name, (MovementCommand,), params)
             globals()[klass_name] = klass
             movement_command_classes2.append(klass)
     # later an individual klass will be instantiated to handle something
@@ -2431,7 +2428,7 @@ def create_command_classes(debug=False):
                     logging.debug("each is {0} and thing[class] is {1}".format(each, thing["class"]))
                 params["size"] += thing["class"].size
         klass_name = cmd_name+"Command"
-        klass = classobj(klass_name, (Command,), params)
+        klass = type(klass_name, (Command,), params)
         globals()[klass_name] = klass
         klasses.append(klass)
     # later an individual klass will be instantiated to handle something
@@ -2548,7 +2545,7 @@ def create_music_command_classes(debug=False):
                     logging.debug("each is {0} and thing[class] is {1}".format(each, thing["class"]))
                 params["size"] += thing["class"].size
         klass_name = cmd_name+"Command"
-        klass = classobj(klass_name, (Command,), params)
+        klass = type(klass_name, (Command,), params)
         globals()[klass_name] = klass
         if klass.macro_name == "notetype":
             klass.allowed_lengths = [1, 2]
@@ -2808,7 +2805,7 @@ def create_effect_command_classes(debug=False):
                     logging.debug("each is {0} and thing[class] is {1}".format(each, thing["class"]))
                 params["size"] += thing["class"].size
         klass_name = cmd_name+"Command"
-        klass = classobj(klass_name, (Command,), params)
+        klass = type(klass_name, (Command,), params)
         globals()[klass_name] = klass
         klasses.append(klass)
     # later an individual klass will be instantiated to handle something

--- a/pokemontools/crystal.py
+++ b/pokemontools/crystal.py
@@ -135,13 +135,7 @@ def load_rom(filename=None):
     and then loads the rom if necessary."""
     if filename == None:
         filename = os.path.join(conf.path, "baserom.gbc")
-    global rom
-    if rom != romstr.RomStr(None) and rom != None:
-        return rom
-    if not isinstance(rom, romstr.RomStr):
-        return direct_load_rom(filename=filename)
-    elif os.lstat(filename).st_size != len(rom):
-        return direct_load_rom(filename)
+    return direct_load_rom(filename)
 
 def direct_load_asm(filename=None):
     if filename == None:
@@ -903,6 +897,8 @@ class PointerLabelParam(MultiByteParam):
                 label = None
             elif result.address != caddress:
                 label = None
+        elif hasattr(result, "keys") and "label" in result.keys():
+            label = result["label"]
         elif result != None:
             label = None
 
@@ -1457,21 +1453,27 @@ def read_event_flags():
     global event_flags
     constants = wram.read_constants(os.path.join(conf.path, 'constants.asm'))
     event_flags = dict(filter(lambda key_value: key_value[1].startswith('EVENT_'), constants.items()))
+    return event_flags
 
 engine_flags = None
 def read_engine_flags():
     global engine_flags
     constants = wram.read_constants(os.path.join(conf.path, 'constants.asm'))
     engine_flags = dict(filter(lambda key_value1: key_value1[1].startswith('ENGINE_'), constants.items()))
+    return engine_flags
 
 class EventFlagParam(MultiByteParam):
     def to_asm(self):
-        if event_flags is None: read_event_flags()
+        global event_flags
+        if event_flags is None:
+            event_flags = read_event_flags()
         return event_flags.get(self.parsed_number) or MultiByteParam.to_asm(self)
 
 class EngineFlagParam(MultiByteParam):
     def to_asm(self):
-        if engine_flags is None: read_engine_flags()
+        global engine_flags
+        if engine_flags is None:
+            engine_flags = read_engine_flags()
         return engine_flags.get(self.parsed_number) or MultiByteParam.to_asm(self)
 
 
@@ -4905,7 +4907,7 @@ class MapHeader(object):
         output += "db " + ", ".join([self.location_on_world_map.to_asm(), self.music.to_asm(), self.time_of_day.to_asm(), self.fishing_group.to_asm()])
         return output
 
-def parse_map_header_at(address, map_group=None, map_id=None, all_map_headers=None, debug=True):
+def parse_map_header_at(address, map_group=None, map_id=None, all_map_headers=None, rom=None, debug=True):
     """parses an arbitrary map header at some address"""
     logging.debug("parsing a map header at {0}".format(hex(address)))
     map_header = MapHeader(address, map_group=map_group, map_id=map_id, debug=debug)
@@ -6111,11 +6113,13 @@ def parse_map_header_by_id(*args, **kwargs):
     map_header_offset = offset + ((map_id - 1) * map_header_byte_size)
     return parse_map_header_at(map_header_offset, all_map_headers=all_map_headers, map_group=map_group, map_id=map_id)
 
-def parse_all_map_headers(map_names, all_map_headers=None, debug=True):
+def parse_all_map_headers(map_names, all_map_headers=None, _parse_map_header_at=None, rom=None, debug=True):
     """
     Calls parse_map_header_at for each map in each map group. Updates the
     map_names structure.
     """
+    if _parse_map_header_at == None:
+        _parse_map_header_at = parse_map_header_at
     if "offset" not in map_names[1]:
         raise Exception("dunno what to do - map_names should have groups with pre-calculated offsets by now")
     for (group_id, group_data) in map_names.items():
@@ -6132,7 +6136,7 @@ def parse_all_map_headers(map_names, all_map_headers=None, debug=True):
             map_header_offset = offset + ((map_id - 1) * map_header_byte_size)
             map_names[group_id][map_id]["header_offset"] = map_header_offset
 
-            new_parsed_map = parse_map_header_at(map_header_offset, map_group=group_id, map_id=map_id, all_map_headers=all_map_headers, debug=debug)
+            new_parsed_map = _parse_map_header_at(map_header_offset, map_group=group_id, map_id=map_id, all_map_headers=all_map_headers, rom=rom, debug=debug)
             map_names[group_id][map_id]["header_new"] = new_parsed_map
 
 class PokedexEntryPointerTable(object):
@@ -6457,12 +6461,15 @@ def split_incbin_line_into_three(line, start_address, byte_count, rom_file=None)
     output += "INCBIN \"baserom.gbc\",$" + hex(third[0])[2:] + ",$" + hex(third[1])[2:] # no newline
     return output
 
-def generate_diff_insert(line_number, newline, debug=False):
+def generate_diff_insert(line_number, newline, _asm=None, debug=False):
     """generates a diff between the old main.asm and the new main.asm
     note: requires python2.7 i think? b/c of subprocess.check_output"""
     global asm
-    original = "\n".join(line for line in asm)
-    newfile = deepcopy(asm)
+    if _asm == None:
+        _asm = asm
+
+    original = "\n".join(line for line in _asm)
+    newfile = deepcopy(_asm)
     newfile[line_number] = newline # possibly inserting multiple lines
     newfile = "\n".join(line for line in newfile)
 
@@ -6472,6 +6479,10 @@ def generate_diff_insert(line_number, newline, debug=False):
 
     original_filename = "ejroqjfoad.temp"
     newfile_filename = "fjiqefo.temp"
+
+    main_path = os.path.join(conf.path, "main.asm")
+    if os.path.exists(main_path):
+        original_filename = main_path
 
     original_fh = open(original_filename, "w")
     original_fh.write(original)
@@ -6487,9 +6498,9 @@ def generate_diff_insert(line_number, newline, debug=False):
         CalledProcessError = None
 
     try:
-        diffcontent = subprocess.check_output("diff -u " + os.path.join(conf.path, "main.asm") + " " + newfile_filename, shell=True)
+        diffcontent = subprocess.check_output("diff -u " + original_filename + " " + newfile_filename, shell=True)
     except (AttributeError, CalledProcessError):
-        p = subprocess.Popen(["diff", "-u", os.path.join(conf.path, "main.asm"), newfile_filename], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(["diff", "-u", original_filename, newfile_filename], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = p.communicate()
         diffcontent = out
 
@@ -7077,11 +7088,18 @@ def get_ram_label(address):
         return wram.wram_labels[address][-1]
     return None
 
-def get_label_for(address):
+def get_label_for(address, _all_labels=None, _script_parse_table=None):
     """
     returns a label assigned to a particular address
     """
     global all_labels
+    global script_parse_table
+
+    if _all_labels == None:
+        _all_labels = all_labels
+
+    if _script_parse_table == None:
+        _script_parse_table = script_parse_table
 
     if address == None:
         return None
@@ -7093,15 +7111,17 @@ def get_label_for(address):
         return None
 
     # the old way
-    for thing in all_labels:
+    for thing in _all_labels:
         if thing["address"] == address:
             return thing["label"]
 
     # the new way
-    obj = script_parse_table[address]
+    obj = _script_parse_table[address]
     if obj:
         if hasattr(obj, "label"):
             return obj.label.name
+        elif hasattr(obj, "keys") and "label" in obj.keys():
+            return obj["label"]
         else:
             return "AlreadyParsedNoDefaultUnknownLabel_" + hex(address)
 
@@ -7320,13 +7340,14 @@ def add_map_offsets_into_map_names(map_group_offsets, map_names=None):
 
 rom_parsed = False
 
-def parse_rom(rom=None):
+def parse_rom(rom=None, _skip_wram_labels=False, _parse_map_header_at=None, debug=False):
     if not rom:
         # read the rom and figure out the offsets for maps
         rom = direct_load_rom()
 
     # make wram.wram_labels available
-    setup_wram_labels()
+    if not _skip_wram_labels:
+        setup_wram_labels()
 
     # figure out the map offsets
     map_group_offsets = load_map_group_offsets(map_group_pointer_table=map_group_pointer_table, map_group_count=map_group_count, rom=rom)
@@ -7335,7 +7356,7 @@ def parse_rom(rom=None):
     add_map_offsets_into_map_names(map_group_offsets, map_names=map_names)
 
     # parse map header bytes for each map
-    parse_all_map_headers(map_names, all_map_headers=all_map_headers)
+    parse_all_map_headers(map_names, all_map_headers=all_map_headers, _parse_map_header_at=_parse_map_header_at, rom=rom, debug=debug)
 
     # find trainers based on scripts and map headers
     # this can only happen after parsing the entire map and map scripts

--- a/pokemontools/crystal.py
+++ b/pokemontools/crystal.py
@@ -244,7 +244,7 @@ def command_debug_information(command_byte=None, map_group=None, map_id=None, ad
     return info1
 
 all_texts = []
-class TextScript:
+class TextScript(object):
     """
     A text is a sequence of bytes (and sometimes commands). It's not the same
     thing as a Script. The bytes are translated into characters based on the
@@ -440,7 +440,7 @@ def find_text_addresses():
     useful for testing parse_text_engine_script_at"""
     return TextScript.find_addresses()
 
-class EncodedText:
+class EncodedText(object):
     """a sequence of bytes that, when decoded, represent readable text
     based on the chars table from preprocessor.py and other places"""
     base_label = "UnknownRawText_"
@@ -1266,7 +1266,7 @@ class MovementPointerLabelParam(PointerLabelParam):
 class MapDataPointerParam(PointerLabelParam):
     pass
 
-class Command:
+class Command(object):
     """
     Note: when dumping to asm, anything in script_parse_table that directly
     inherits Command should not be .to_asm()'d.
@@ -1627,7 +1627,7 @@ def create_movement_commands(debug=False):
 movement_command_classes = create_movement_commands()
 
 all_movements = []
-class ApplyMovementData:
+class ApplyMovementData(object):
     base_label = "MovementData_"
 
     def __init__(self, address, map_group=None, map_id=None, debug=False, label=None, force=False):
@@ -2436,7 +2436,7 @@ def create_command_classes(debug=False):
 command_classes = create_command_classes()
 
 
-class BigEndianParam:
+class BigEndianParam(object):
     """big-endian word"""
     size = 2
     should_be_decimal = False
@@ -2888,7 +2888,7 @@ stop_points = [0x1aafa2,
                0x9f58f, # battle tower
                0x9f62f, # battle tower
               ]
-class Script:
+class Script(object):
     base_label = "UnknownScript_"
     def __init__(self, *args, **kwargs):
         self.address = None
@@ -3466,7 +3466,7 @@ class TrainerFragmentParam(PointerLabelParam):
         return deps
 
 trainer_group_table = None
-class TrainerGroupTable:
+class TrainerGroupTable(object):
     """
     A list of pointers.
 
@@ -3521,7 +3521,7 @@ class TrainerGroupTable:
         output = "".join([str("dw "+get_label_for(header.address)+"\n") for header in self.headers])
         return output
 
-class TrainerGroupHeader:
+class TrainerGroupHeader(object):
     """
     A trainer group header is a repeating list of individual trainer headers.
 
@@ -3614,7 +3614,7 @@ class TrainerGroupHeader:
         output = "\n\n".join(["; "+header.make_constant_name()+" ("+str(header.trainer_id)+") at "+hex(header.address)+"\n"+header.to_asm() for header in self.individual_trainer_headers])
         return output
 
-class TrainerHeader:
+class TrainerHeader(object):
     """
     <Trainer Name> <0x50> <Data type> <Pokémon Data>+ <0xFF>
 
@@ -3719,7 +3719,7 @@ class TrainerHeader:
         output += "\n; last_address="+hex(self.last_address)+" size="+str(self.size)
         return output
 
-class TrainerPartyMonParser:
+class TrainerPartyMonParser(object):
     """
     Just a generic trainer party mon parser.
     Don't use this directly. Only use the child classes.
@@ -4409,7 +4409,7 @@ def old_parse_people_event_bytes(some_bytes, address=None, map_group=None, map_i
     return people_events
 
 
-class SignpostRemoteBase:
+class SignpostRemoteBase(object):
     def __init__(self, address, bank=None, map_group=None, map_id=None, signpost=None, debug=False, label=None):
         self.address = address
         self.last_address = address + self.size
@@ -4848,7 +4848,7 @@ class TimeOfDayParam(DecimalParam):
         return DecimalParam.to_asm(self)
 
 
-class MapHeader:
+class MapHeader(object):
     base_label = "MapHeader_"
 
     def __init__(self, address, map_group=None, map_id=None, debug=True, label=None, bank=0x25):
@@ -4934,7 +4934,7 @@ def get_direction(connection_byte, connection_id):
 
     return results[connection_id]
 
-class SecondMapHeader:
+class SecondMapHeader(object):
     base_label = "SecondMapHeader_"
 
     def __init__(self, address, map_group=None, map_id=None, debug=True, bank=None, label=None):
@@ -5076,7 +5076,7 @@ wrong_easts = []
 wrong_souths = []
 wrong_wests = []
 
-class Connection:
+class Connection(object):
     size = 12
 
     def __init__(self, address, direction=None, map_group=None, map_id=None, debug=True, smh=None):
@@ -5740,7 +5740,7 @@ def parse_second_map_header_at(address, map_group=None, map_id=None, debug=True)
     all_second_map_headers.append(smh)
     return smh
 
-class MapBlockData:
+class MapBlockData(object):
     base_label = "MapBlockData_"
     maps_path = os.path.realpath(os.path.join(conf.path, "maps"))
 
@@ -5786,7 +5786,7 @@ class MapBlockData:
         return "INCBIN \"maps/"+self.map_name+".blk\""
 
 
-class MapEventHeader:
+class MapEventHeader(object):
     base_label = "MapEventHeader_"
 
     def __init__(self, address, map_group=None, map_id=None, debug=True, bank=None, label=None):
@@ -5925,7 +5925,7 @@ def parse_map_event_header_at(address, map_group=None, map_id=None, debug=True, 
     all_map_event_headers.append(ev)
     return ev
 
-class MapScriptHeader:
+class MapScriptHeader(object):
     """parses a script header
 
     This structure allows the game to have e.g. one-time only events on a map
@@ -6135,7 +6135,7 @@ def parse_all_map_headers(map_names, all_map_headers=None, debug=True):
             new_parsed_map = parse_map_header_at(map_header_offset, map_group=group_id, map_id=map_id, all_map_headers=all_map_headers, debug=debug)
             map_names[group_id][map_id]["header_new"] = new_parsed_map
 
-class PokedexEntryPointerTable:
+class PokedexEntryPointerTable(object):
     """
     A list of pointers.
     """
@@ -6185,7 +6185,7 @@ class PokedexEntryPointerTable:
         output = "".join([str("dw "+get_label_for(entry.address)+"\n") for entry in self.entries])
         return output
 
-class PokedexEntry:
+class PokedexEntry(object):
     def __init__(self, address, pokemon_id):
         self.address = address
         self.dependencies = None
@@ -6527,7 +6527,7 @@ def apply_diff(diff, try_fixing=True, do_compile=True):
 
 from .crystalparts.asmline import AsmLine
 
-class Incbin:
+class Incbin(object):
     def __init__(self, line, bank=None, debug=False):
         self.line = line
         self.bank = bank
@@ -6614,7 +6614,7 @@ class Incbin:
 
         return incbins
 
-class AsmSection:
+class AsmSection(object):
     def __init__(self, line):
         self.bank_id = None
         self.line = line
@@ -6656,7 +6656,7 @@ def load_asm2(filename=None, force=False):
         new_asm = Asm(filename=filename)
     return new_asm
 
-class Asm:
+class Asm(object):
     """controls the overall asm output"""
     def __init__(self, filename=None, debug=True):
         if filename == None:
@@ -7111,7 +7111,7 @@ def get_label_for(address):
 # at least until the two approaches are merged in the code base.
 all_new_labels = []
 
-class Label:
+class Label(object):
     """
     Every object in script_parse_table is given a label.
 

--- a/pokemontools/crystal.py
+++ b/pokemontools/crystal.py
@@ -2,6 +2,8 @@
 """
 utilities to help disassemble pokémon crystal
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
@@ -47,27 +49,27 @@ texts = []
 # this doesn't do anything but is still used in TextScript
 constant_abbreviation_bytes = {}
 
-import helpers
-import chars
-import labels
-import pksv
-import romstr
-import pointers
-import interval_map
-import trainers
-import move_constants
-import pokemon_constants
-import item_constants
-import wram
-import exceptions
+from . import helpers
+from . import chars
+from . import labels
+from . import pksv
+from . import romstr
+from . import pointers
+from . import interval_map
+from . import trainers
+from . import move_constants
+from . import pokemon_constants
+from . import item_constants
+from . import wram
+from . import exceptions
 
-import addresses
+from . import addresses
 is_valid_address = addresses.is_valid_address
 
-import old_text_script
+from . import old_text_script
 OldTextScript = old_text_script
 
-import configuration
+from . import configuration
 conf = configuration.Config()
 
 data_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data/pokecrystal/")
@@ -75,8 +77,8 @@ conf.wram = os.path.join(data_path, "wram.asm")
 conf.gbhw = os.path.join(data_path, "gbhw.asm")
 conf.hram = os.path.join(data_path, "hram.asm")
 
-from map_names import map_names
-from song_names import song_names
+from .map_names import map_names
+from .song_names import song_names
 
 # ---- script_parse_table explanation ----
 # This is an IntervalMap that keeps track of previously parsed scripts, texts
@@ -1457,13 +1459,13 @@ event_flags = None
 def read_event_flags():
     global event_flags
     constants = wram.read_constants(os.path.join(conf.path, 'constants.asm'))
-    event_flags = dict(filter(lambda (key, value): value.startswith('EVENT_'), constants.items()))
+    event_flags = dict(filter(lambda key_value: key_value[1].startswith('EVENT_'), constants.items()))
 
 engine_flags = None
 def read_engine_flags():
     global engine_flags
     constants = wram.read_constants(os.path.join(conf.path, 'constants.asm'))
-    engine_flags = dict(filter(lambda (key, value): value.startswith('ENGINE_'), constants.items()))
+    engine_flags = dict(filter(lambda key_value1: key_value1[1].startswith('ENGINE_'), constants.items()))
 
 class EventFlagParam(MultiByteParam):
     def to_asm(self):
@@ -1761,9 +1763,9 @@ class ApplyMovementData:
 
 def print_all_movements():
     for each in all_movements:
-        print each.to_asm()
-        print "------------------"
-    print "done"
+        print(each.to_asm())
+        print("------------------")
+    print("done")
 
 class TextCommand(Command):
     # an individual text command will not end it
@@ -2852,9 +2854,9 @@ def pretty_print_pksv_no_names():
     for (command_byte, addresses) in pksv_no_names.items():
         if command_byte in pksv.pksv_crystal_unknowns:
             continue
-        print hex(command_byte) + " appearing in these scripts: "
+        print(hex(command_byte) + " appearing in these scripts: ")
         for address in addresses:
-            print "    " + hex(address)
+            print("    " + hex(address))
 
 recursive_scripts = set([])
 def rec_parse_script_engine_script_at(address, origin=None, debug=True):
@@ -3084,7 +3086,7 @@ class Script:
     def old_parse(self, *args, **kwargs):
         """included from old_parse_scripts"""
 
-import old_parse_scripts
+from . import old_parse_scripts
 Script.old_parse = old_parse_scripts.old_parse
 
 def parse_script_engine_script_at(address, map_group=None, map_id=None, force=False, debug=True, origin=True):
@@ -4249,8 +4251,8 @@ class PeopleEvent(Command):
                 lower_bits = color_function_byte & 0xF
                 higher_bits = color_function_byte >> 4
                 is_regular_script = lower_bits == 00
-                is_give_item = lower_bits == 01
-                is_trainer = lower_bits == 02
+                is_give_item = lower_bits == 0o1
+                is_trainer = lower_bits == 0o2
             current_address += obj.size
             self.size += obj.size
             i += 1
@@ -4324,9 +4326,9 @@ def old_parse_people_event_bytes(some_bytes, address=None, map_group=None, map_i
 
         is_regular_script = lower_bits == 00
         # pointer points to script
-        is_give_item = lower_bits == 01
+        is_give_item = lower_bits == 0o1
         # pointer points to [Item no.][Amount]
-        is_trainer = lower_bits == 02
+        is_trainer = lower_bits == 0o2
         # pointer points to trainer header
 
         # goldmap called these next two bytes "text_block" and "text_bank"?
@@ -6117,7 +6119,7 @@ def parse_all_map_headers(map_names, all_map_headers=None, debug=True):
     Calls parse_map_header_at for each map in each map group. Updates the
     map_names structure.
     """
-    if not map_names[1].has_key("offset"):
+    if "offset" not in map_names[1]:
         raise Exception("dunno what to do - map_names should have groups with pre-calculated offsets by now")
     for (group_id, group_data) in map_names.items():
         offset = group_data["offset"]
@@ -6240,7 +6242,7 @@ for map_group_id in map_names.keys():
         # skip if we maybe already have the 'offset' label set in this map group
         if map_id == "offset": continue
         # skip if we provided a pre-set value for the map's label
-        if map_group[map_id].has_key("label"): continue
+        if "label" in map_group[map_id]: continue
         # convience alias
         map_data = map_group[map_id]
         # clean up the map name to be an asm label
@@ -6302,7 +6304,7 @@ def get_dependencies_for(some_object, recompute=False, global_dependencies=set()
         else:
             some_object.get_dependencies(recompute=recompute, global_dependencies=global_dependencies)
         return global_dependencies
-    except RuntimeError, e:
+    except RuntimeError as e:
         # 1552, 1291, 2075, 1552, 1291...
 
         errorargs = {
@@ -6521,13 +6523,12 @@ def apply_diff(diff, try_fixing=True, do_compile=True):
         try:
             subprocess.check_call("cd " + conf.path + "; make clean; make", shell=True)
             return True
-        except Exception, exc:
+        except Exception as exc:
             if try_fixing:
                 os.system("mv " + os.path.join(conf.path, "main1.asm") + " " + os.path.join(conf.path, "main.asm"))
             return False
 
-import crystalparts.asmline
-AsmLine = crystalparts.asmline.AsmLine
+from .crystalparts.asmline import AsmLine
 
 class Incbin:
     def __init__(self, line, bank=None, debug=False):
@@ -6548,7 +6549,7 @@ class Incbin:
             logging.debug("Incbin.parse start is {0}".format(start))
         try:
             start = eval(start)
-        except Exception, e:
+        except Exception as e:
             logging.debug("start is {0}".format(start))
             raise Exception("problem with evaluating interval range: " + str(e))
 

--- a/pokemontools/crystalparts/old_parsers.py
+++ b/pokemontools/crystalparts/old_parsers.py
@@ -255,9 +255,9 @@ def old_parse_people_event_bytes(some_bytes, address=None, map_group=None, map_i
 
         is_regular_script = lower_bits == 00
         # pointer points to script
-        is_give_item = lower_bits == 01
+        is_give_item = lower_bits == 0o1
         # pointer points to [Item no.][Amount]
-        is_trainer = lower_bits == 02
+        is_trainer = lower_bits == 0o2
         # pointer points to trainer header
 
         # goldmap called these next two bytes "text_block" and "text_bank"?

--- a/pokemontools/disassemble_map_scripts.py
+++ b/pokemontools/disassemble_map_scripts.py
@@ -3,9 +3,10 @@
 Dump out asm for scripting things in bank $25. This script will modify main.asm
 and insert all scripting commands.
 """
+from __future__ import absolute_import
 
-import crystal
-import gbz80disasm
+from . import crystal
+from . import gbz80disasm
 
 rom = crystal.load_rom()
 roml = [ord(x) for x in rom]

--- a/pokemontools/dump_gfx.py
+++ b/pokemontools/dump_gfx.py
@@ -1,7 +1,9 @@
-from gfx import *
-from pokemon_constants import pokemon_constants
-import trainers
-import romstr
+from __future__ import print_function
+from __future__ import absolute_import
+from .gfx import *
+from .pokemon_constants import pokemon_constants
+from . import trainers
+from . import romstr
 
 def load_rom(filename=config.rom_path):
     rom = romstr.RomStr.load(filename=filename)
@@ -357,7 +359,7 @@ def dump_pic_animations(addresses={'bitmasks': 'BitmasksPointers', 'frames': 'Fr
             tiles = (x for x in frame[1])
             for j, bit in enumerate(bitmask):
                 if bit:
-                    tmap[(i + 1) * length + j] = tiles.next()
+                    tmap[(i + 1) * length + j] = next(tiles)
 
         filename = os.path.join(directory, 'front.{0}x{0}.2bpp.lz'.format(size))
         tiles = get_tiles(Decompressed(open(filename).read()).output)
@@ -495,7 +497,7 @@ def dump_trainer_pals():
         to_file('../'+dir+filename, pal_data)
 
         spacing = ' ' * (12 - len(name))
-        print name+'Palette:'+spacing+' INCBIN"'+dir+filename+'"'
+        print(name+'Palette:'+spacing+' INCBIN"'+dir+filename+'"')
 
 
 def get_uncompressed_gfx(start, num_tiles, filename):

--- a/pokemontools/gbz80disasm.py
+++ b/pokemontools/gbz80disasm.py
@@ -850,7 +850,7 @@ class Disassembler(object):
 		if include_last_address:
 			output += "; " + hex(offset)
 		
-		return [output, offset, stop_offset, byte_labels, data_labels]
+		return [output, offset, stop_offset, byte_labels, data_tables]
 
 def get_raw_addr(addr):
 	if addr:

--- a/pokemontools/gbz80disasm.py
+++ b/pokemontools/gbz80disasm.py
@@ -4,998 +4,909 @@ GBC disassembler
 """
 
 import os
-import sys
-from copy import copy, deepcopy
+import argparse
 from ctypes import c_int8
 
 import configuration
 from wram import read_constants
 
-temp_opt_table = [
-  [ "ADC A", 0x8f, 0 ],
-  [ "ADC B", 0x88, 0 ],
-  [ "ADC C", 0x89, 0 ],
-  [ "ADC D", 0x8a, 0 ],
-  [ "ADC E", 0x8b, 0 ],
-  [ "ADC H", 0x8c, 0 ],
-  [ "ADC [HL]", 0x8e, 0 ],
-  [ "ADC L", 0x8d, 0 ],
-  [ "ADC x", 0xce, 1 ],
-  [ "ADD A", 0x87, 0 ],
-  [ "ADD B", 0x80, 0 ],
-  [ "ADD C", 0x81, 0 ],
-  [ "ADD D", 0x82, 0 ],
-  [ "ADD E", 0x83, 0 ],
-  [ "ADD H", 0x84, 0 ],
-  [ "ADD [HL]", 0x86, 0 ],
-  [ "ADD HL, BC", 0x9, 0 ],
-  [ "ADD HL, DE", 0x19, 0 ],
-  [ "ADD HL, HL", 0x29, 0 ],
-  [ "ADD HL, SP", 0x39, 0 ],
-  [ "ADD L", 0x85, 0 ],
-  [ "ADD SP, x", 0xe8, 1 ],
-  [ "ADD x", 0xc6, 1 ],
-  [ "AND A", 0xa7, 0 ],
-  [ "AND B", 0xa0, 0 ],
-  [ "AND C", 0xa1, 0 ],
-  [ "AND D", 0xa2, 0 ],
-  [ "AND E", 0xa3, 0 ],
-  [ "AND H", 0xa4, 0 ],
-  [ "AND [HL]", 0xa6, 0 ],
-  [ "AND L", 0xa5, 0 ],
-  [ "AND x", 0xe6, 1 ],
-  [ "BIT 0, A", 0x47cb, 3 ],
-  [ "BIT 0, B", 0x40cb, 3 ],
-  [ "BIT 0, C", 0x41cb, 3 ],
-  [ "BIT 0, D", 0x42cb, 3 ],
-  [ "BIT 0, E", 0x43cb, 3 ],
-  [ "BIT 0, H", 0x44cb, 3 ],
-  [ "BIT 0, [HL]", 0x46cb, 3 ],
-  [ "BIT 0, L", 0x45cb, 3 ],
-  [ "BIT 1, A", 0x4fcb, 3 ],
-  [ "BIT 1, B", 0x48cb, 3 ],
-  [ "BIT 1, C", 0x49cb, 3 ],
-  [ "BIT 1, D", 0x4acb, 3 ],
-  [ "BIT 1, E", 0x4bcb, 3 ],
-  [ "BIT 1, H", 0x4ccb, 3 ],
-  [ "BIT 1, [HL]", 0x4ecb, 3 ],
-  [ "BIT 1, L", 0x4dcb, 3 ],
-  [ "BIT 2, A", 0x57cb, 3 ],
-  [ "BIT 2, B", 0x50cb, 3 ],
-  [ "BIT 2, C", 0x51cb, 3 ],
-  [ "BIT 2, D", 0x52cb, 3 ],
-  [ "BIT 2, E", 0x53cb, 3 ],
-  [ "BIT 2, H", 0x54cb, 3 ],
-  [ "BIT 2, [HL]", 0x56cb, 3 ],
-  [ "BIT 2, L", 0x55cb, 3 ],
-  [ "BIT 3, A", 0x5fcb, 3 ],
-  [ "BIT 3, B", 0x58cb, 3 ],
-  [ "BIT 3, C", 0x59cb, 3 ],
-  [ "BIT 3, D", 0x5acb, 3 ],
-  [ "BIT 3, E", 0x5bcb, 3 ],
-  [ "BIT 3, H", 0x5ccb, 3 ],
-  [ "BIT 3, [HL]", 0x5ecb, 3 ],
-  [ "BIT 3, L", 0x5dcb, 3 ],
-  [ "BIT 4, A", 0x67cb, 3 ],
-  [ "BIT 4, B", 0x60cb, 3 ],
-  [ "BIT 4, C", 0x61cb, 3 ],
-  [ "BIT 4, D", 0x62cb, 3 ],
-  [ "BIT 4, E", 0x63cb, 3 ],
-  [ "BIT 4, H", 0x64cb, 3 ],
-  [ "BIT 4, [HL]", 0x66cb, 3 ],
-  [ "BIT 4, L", 0x65cb, 3 ],
-  [ "BIT 5, A", 0x6fcb, 3 ],
-  [ "BIT 5, B", 0x68cb, 3 ],
-  [ "BIT 5, C", 0x69cb, 3 ],
-  [ "BIT 5, D", 0x6acb, 3 ],
-  [ "BIT 5, E", 0x6bcb, 3 ],
-  [ "BIT 5, H", 0x6ccb, 3 ],
-  [ "BIT 5, [HL]", 0x6ecb, 3 ],
-  [ "BIT 5, L", 0x6dcb, 3 ],
-  [ "BIT 6, A", 0x77cb, 3 ],
-  [ "BIT 6, B", 0x70cb, 3 ],
-  [ "BIT 6, C", 0x71cb, 3 ],
-  [ "BIT 6, D", 0x72cb, 3 ],
-  [ "BIT 6, E", 0x73cb, 3 ],
-  [ "BIT 6, H", 0x74cb, 3 ],
-  [ "BIT 6, [HL]", 0x76cb, 3 ],
-  [ "BIT 6, L", 0x75cb, 3 ],
-  [ "BIT 7, A", 0x7fcb, 3 ],
-  [ "BIT 7, B", 0x78cb, 3 ],
-  [ "BIT 7, C", 0x79cb, 3 ],
-  [ "BIT 7, D", 0x7acb, 3 ],
-  [ "BIT 7, E", 0x7bcb, 3 ],
-  [ "BIT 7, H", 0x7ccb, 3 ],
-  [ "BIT 7, [HL]", 0x7ecb, 3 ],
-  [ "BIT 7, L", 0x7dcb, 3 ],
-  [ "CALL C, ?", 0xdc, 2 ],
-  [ "CALL NC, ?", 0xd4, 2 ],
-  [ "CALL NZ, ?", 0xc4, 2 ],
-  [ "CALL Z, ?", 0xcc, 2 ],
-  [ "CALL ?", 0xcd, 2 ],
-  [ "CCF", 0x3f, 0 ],
-  [ "CP A", 0xbf, 0 ],
-  [ "CP B", 0xb8, 0 ],
-  [ "CP C", 0xb9, 0 ],
-  [ "CP D", 0xba, 0 ],
-  [ "CP E", 0xbb, 0 ],
-  [ "CP H", 0xbc, 0 ],
-  [ "CP [HL]", 0xbe, 0 ],
-  [ "CPL", 0x2f, 0 ],
-  [ "CP L", 0xbd, 0 ],
-  [ "CP x", 0xfe, 1 ],
-  [ "DAA", 0x27, 0 ],
-  [ "DEBUG", 0xed, 0 ],
-  [ "DEC A", 0x3d, 0 ],
-  [ "DEC B", 0x5, 0 ],
-  [ "DEC BC", 0xb, 0 ],
-  [ "DEC C", 0xd, 0 ],
-  [ "DEC D", 0x15, 0 ],
-  [ "DEC DE", 0x1b, 0 ],
-  [ "DEC E", 0x1d, 0 ],
-  [ "DEC H", 0x25, 0 ],
-  [ "DEC HL", 0x2b, 0 ],
-  [ "DEC [HL]", 0x35, 0 ],
-  [ "DEC L", 0x2d, 0 ],
-  [ "DEC SP", 0x3b, 0 ],
-  [ "DI", 0xf3, 0 ],
-  [ "EI", 0xfb, 0 ],
-  [ "HALT", 0x76, 0 ],
-  [ "INC A", 0x3c, 0 ],
-  [ "INC B", 0x4, 0 ],
-  [ "INC BC", 0x3, 0 ],
-  [ "INC C", 0xc, 0 ],
-  [ "INC D", 0x14, 0 ],
-  [ "INC DE", 0x13, 0 ],
-  [ "INC E", 0x1c, 0 ],
-  [ "INC H", 0x24, 0 ],
-  [ "INC HL", 0x23, 0 ],
-  [ "INC [HL]", 0x34, 0 ],
-  [ "INC L", 0x2c, 0 ],
-  [ "INC SP", 0x33, 0 ],
-  [ "JP C, ?", 0xda, 2 ],
-  [ "JP [HL]", 0xe9, 0 ],
-  [ "JP NC, ?", 0xd2, 2 ],
-  [ "JP NZ, ?", 0xc2, 2 ],
-  [ "JP Z, ?", 0xca, 2 ],
-  [ "JP ?", 0xc3, 2 ],
-  [ "JR C, x", 0x38, 1 ],
-  [ "JR NC, x", 0x30, 1 ],
-  [ "JR NZ, x", 0x20, 1 ],
-  [ "JR Z, x", 0x28, 1 ],
-  [ "JR x", 0x18, 1 ],
-  [ "LD A, A", 0x7f, 0 ],
-  [ "LD A, B", 0x78, 0 ],
-  [ "LD A, C", 0x79, 0 ],
-  [ "LD A, D", 0x7a, 0 ],
-  [ "LD A, E", 0x7b, 0 ],
-  [ "LD A, H", 0x7c, 0 ],
-  [ "LD A, L", 0x7d, 0 ],
-  [ "LD A, [$FF00+C]", 0xf2, 0 ],
-  [ "LD A, [$FF00+x]", 0xf0, 1 ],
-#  [ "LDH A, [x]", 0xf0, 1 ], # rgbds has trouble with this one?
-  [ "LD A, [BC]", 0xa, 0 ],
-  [ "LD A, [DE]", 0x1a, 0 ],
-#  [ "LD A, [HL+]", 0x2a, 0 ],
-#  [ "LD A, [HL-]", 0x3a, 0 ],
-  [ "LD A, [HL]", 0x7e, 0 ],
-  [ "LD A, [HLD]", 0x3a, 0 ],
-  [ "LD A, [HLI]", 0x2a, 0 ],
-  [ "LD A, [?]", 0xfa, 2 ],
-  [ "LD A, x", 0x3e, 1 ],
-  [ "LD B, A", 0x47, 0 ],
-  [ "LD B, B", 0x40, 0 ],
-  [ "LD B, C", 0x41, 0 ],
-  [ "LD [BC], A", 0x2, 0 ],
-  [ "LD B, D", 0x42, 0 ],
-  [ "LD B, E", 0x43, 0 ],
-  [ "LD B, H", 0x44, 0 ],
-  [ "LD B, [HL]", 0x46, 0 ],
-  [ "LD B, L", 0x45, 0 ],
-  [ "LD B, x", 0x6, 1 ],
-  [ "LD C, A", 0x4f, 0 ],
-  [ "LD C, B", 0x48, 0 ],
-  [ "LD C, C", 0x49, 0 ],
-  [ "LD C, D", 0x4a, 0 ],
-  [ "LD C, E", 0x4b, 0 ],
-  [ "LD C, H", 0x4c, 0 ],
-  [ "LD C, [HL]", 0x4e, 0 ],
-  [ "LD C, L", 0x4d, 0 ],
-  [ "LD C, x", 0xe, 1 ],
-  [ "LD D, A", 0x57, 0 ],
-#  [ "LDD A, [HL]", 0x3a, 0 ],
-  [ "LD D, B", 0x50, 0 ],
-  [ "LD D, C", 0x51, 0 ],
-  [ "LD D, D", 0x52, 0 ],
-  [ "LD D, E", 0x53, 0 ],
-  [ "LD [DE], A", 0x12, 0 ],
-  [ "LD D, H", 0x54, 0 ],
-  [ "LD D, [HL]", 0x56, 0 ],
-#  [ "LDD [HL], A", 0x32, 0 ],
-  [ "LD D, L", 0x55, 0 ],
-  [ "LD D, x", 0x16, 1 ],
-  [ "LD E, A", 0x5f, 0 ],
-  [ "LD E, B", 0x58, 0 ],
-  [ "LD E, C", 0x59, 0 ],
-  [ "LD E, D", 0x5a, 0 ],
-  [ "LD E, E", 0x5b, 0 ],
-  [ "LD E, H", 0x5c, 0 ],
-  [ "LD E, [HL]", 0x5e, 0 ],
-  [ "LD E, L", 0x5d, 0 ],
-  [ "LD E, x", 0x1e, 1 ],
-  [ "LD [$FF00+C], A", 0xe2, 0 ],
-  [ "LD [$FF00+x], A", 0xe0, 1 ],
-#  [ "LDH [x], A", 0xe0, 1 ],
-  [ "LD H, A", 0x67, 0 ],
-  [ "LD H, B", 0x60, 0 ],
-  [ "LD H, C", 0x61, 0 ],
-  [ "LD H, D", 0x62, 0 ],
-  [ "LD H, E", 0x63, 0 ],
-  [ "LD H, H", 0x64, 0 ],
-  [ "LD H, [HL]", 0x66, 0 ],
-  [ "LD H, L", 0x65, 0 ],
-#  [ "LD [HL+], A", 0x22, 0 ],
-#  [ "LD [HL-], A", 0x32, 0 ],
-  [ "LD [HL], A", 0x77, 0 ],
-  [ "LD [HL], B", 0x70, 0 ],
-  [ "LD [HL], C", 0x71, 0 ],
-  [ "LD [HL], D", 0x72, 0 ],
-  [ "LD [HLD], A", 0x32, 0 ],
-  [ "LD [HL], E", 0x73, 0 ],
-  [ "LD [HL], H", 0x74, 0 ],
-  [ "LD [HLI], A", 0x22, 0 ],
-  [ "LD [HL], L", 0x75, 0 ],
-#  [ "LD HL, SP+x", 0xf8, 1 ], # rgbds uses [sp+x]
-  [ "LD HL, [SP+x]", 0xf8, 1 ],
-  [ "LD [HL], x", 0x36, 1 ],
-  [ "LD H, x", 0x26, 1 ],
-#  [ "LDI A, [HL]", 0x2a, 0 ],
-#  [ "LDI [HL], A", 0x22, 0 ],
-  [ "LD L, A", 0x6f, 0 ],
-  [ "LD L, B", 0x68, 0 ],
-  [ "LD L, C", 0x69, 0 ],
-  [ "LD L, D", 0x6a, 0 ],
-  [ "LD L, E", 0x6b, 0 ],
-  [ "LD L, H", 0x6c, 0 ],
-  [ "LD L, [HL]", 0x6e, 0 ],
-  [ "LD L, L", 0x6d, 0 ],
-  [ "LD L, x", 0x2e, 1 ],
-#  [ "LD PC, HL", 0xe9, 0 ], #prefer jp [hl]
-  [ "LD SP, HL", 0xf9, 0 ],
-  [ "LD BC, ?", 0x1, 2 ],
-  [ "LD DE, ?", 0x11, 2 ],
-  [ "LD HL, ?", 0x21, 2 ],
-  [ "LD SP, ?", 0x31, 2 ],
-  [ "LD [?], SP", 0x8, 2 ],
-  [ "LD [?], A", 0xea, 2 ],
-  [ "NOP", 0x0, 0 ],
-  [ "OR A", 0xb7, 0 ],
-  [ "OR B", 0xb0, 0 ],
-  [ "OR C", 0xb1, 0 ],
-  [ "OR D", 0xb2, 0 ],
-  [ "OR E", 0xb3, 0 ],
-  [ "OR H", 0xb4, 0 ],
-  [ "OR [HL]", 0xb6, 0 ],
-  [ "OR L", 0xb5, 0 ],
-  [ "OR x", 0xf6, 1 ],
-  [ "POP AF", 0xf1, 0 ],
-  [ "POP BC", 0xc1, 0 ],
-  [ "POP DE", 0xd1, 0 ],
-  [ "POP HL", 0xe1, 0 ],
-  [ "PUSH AF", 0xf5, 0 ],
-  [ "PUSH BC", 0xc5, 0 ],
-  [ "PUSH DE", 0xd5, 0 ],
-  [ "PUSH HL", 0xe5, 0 ],
-  [ "RES 0, A", 0x87cb, 3 ],
-  [ "RES 0, B", 0x80cb, 3 ],
-  [ "RES 0, C", 0x81cb, 3 ],
-  [ "RES 0, D", 0x82cb, 3 ],
-  [ "RES 0, E", 0x83cb, 3 ],
-  [ "RES 0, H", 0x84cb, 3 ],
-  [ "RES 0, [HL]", 0x86cb, 3 ],
-  [ "RES 0, L", 0x85cb, 3 ],
-  [ "RES 1, A", 0x8fcb, 3 ],
-  [ "RES 1, B", 0x88cb, 3 ],
-  [ "RES 1, C", 0x89cb, 3 ],
-  [ "RES 1, D", 0x8acb, 3 ],
-  [ "RES 1, E", 0x8bcb, 3 ],
-  [ "RES 1, H", 0x8ccb, 3 ],
-  [ "RES 1, [HL]", 0x8ecb, 3 ],
-  [ "RES 1, L", 0x8dcb, 3 ],
-  [ "RES 2, A", 0x97cb, 3 ],
-  [ "RES 2, B", 0x90cb, 3 ],
-  [ "RES 2, C", 0x91cb, 3 ],
-  [ "RES 2, D", 0x92cb, 3 ],
-  [ "RES 2, E", 0x93cb, 3 ],
-  [ "RES 2, H", 0x94cb, 3 ],
-  [ "RES 2, [HL]", 0x96cb, 3 ],
-  [ "RES 2, L", 0x95cb, 3 ],
-  [ "RES 3, A", 0x9fcb, 3 ],
-  [ "RES 3, B", 0x98cb, 3 ],
-  [ "RES 3, C", 0x99cb, 3 ],
-  [ "RES 3, D", 0x9acb, 3 ],
-  [ "RES 3, E", 0x9bcb, 3 ],
-  [ "RES 3, H", 0x9ccb, 3 ],
-  [ "RES 3, [HL]", 0x9ecb, 3 ],
-  [ "RES 3, L", 0x9dcb, 3 ],
-  [ "RES 4, A", 0xa7cb, 3 ],
-  [ "RES 4, B", 0xa0cb, 3 ],
-  [ "RES 4, C", 0xa1cb, 3 ],
-  [ "RES 4, D", 0xa2cb, 3 ],
-  [ "RES 4, E", 0xa3cb, 3 ],
-  [ "RES 4, H", 0xa4cb, 3 ],
-  [ "RES 4, [HL]", 0xa6cb, 3 ],
-  [ "RES 4, L", 0xa5cb, 3 ],
-  [ "RES 5, A", 0xafcb, 3 ],
-  [ "RES 5, B", 0xa8cb, 3 ],
-  [ "RES 5, C", 0xa9cb, 3 ],
-  [ "RES 5, D", 0xaacb, 3 ],
-  [ "RES 5, E", 0xabcb, 3 ],
-  [ "RES 5, H", 0xaccb, 3 ],
-  [ "RES 5, [HL]", 0xaecb, 3 ],
-  [ "RES 5, L", 0xadcb, 3 ],
-  [ "RES 6, A", 0xb7cb, 3 ],
-  [ "RES 6, B", 0xb0cb, 3 ],
-  [ "RES 6, C", 0xb1cb, 3 ],
-  [ "RES 6, D", 0xb2cb, 3 ],
-  [ "RES 6, E", 0xb3cb, 3 ],
-  [ "RES 6, H", 0xb4cb, 3 ],
-  [ "RES 6, [HL]", 0xb6cb, 3 ],
-  [ "RES 6, L", 0xb5cb, 3 ],
-  [ "RES 7, A", 0xbfcb, 3 ],
-  [ "RES 7, B", 0xb8cb, 3 ],
-  [ "RES 7, C", 0xb9cb, 3 ],
-  [ "RES 7, D", 0xbacb, 3 ],
-  [ "RES 7, E", 0xbbcb, 3 ],
-  [ "RES 7, H", 0xbccb, 3 ],
-  [ "RES 7, [HL]", 0xbecb, 3 ],
-  [ "RES 7, L", 0xbdcb, 3 ],
-  [ "RETI", 0xd9, 0 ],
-  [ "RET C", 0xd8, 0 ],
-  [ "RET NC", 0xd0, 0 ],
-  [ "RET NZ", 0xc0, 0 ],
-  [ "RET Z", 0xc8, 0 ],
-  [ "RET", 0xc9, 0 ],
-  [ "RLA", 0x17, 0 ],
-  [ "RL A", 0x17cb, 3 ],
-  [ "RL B", 0x10cb, 3 ],
-  [ "RL C", 0x11cb, 3 ],
-  [ "RLCA", 0x7, 0 ],
-  [ "RLC A", 0x7cb, 3 ],
-  [ "RLC B", 0xcb, 3 ],
-  [ "RLC C", 0x1cb, 3 ],
-  [ "RLC D", 0x2cb, 3 ],
-  [ "RLC E", 0x3cb, 3 ],
-  [ "RLC H", 0x4cb, 3 ],
-  [ "RLC [HL]", 0x6cb, 3 ],
-  [ "RLC L", 0x5cb, 3 ],
-  [ "RL D", 0x12cb, 3 ],
-  [ "RL E", 0x13cb, 3 ],
-  [ "RL H", 0x14cb, 3 ],
-  [ "RL [HL]", 0x16cb, 3 ],
-  [ "RL L", 0x15cb, 3 ],
-  [ "RRA", 0x1f, 0 ],
-  [ "RR A", 0x1fcb, 3 ],
-  [ "RR B", 0x18cb, 3 ],
-  [ "RR C", 0x19cb, 3 ],
-  [ "RRCA", 0xf, 0 ],
-  [ "RRC A", 0xfcb, 3 ],
-  [ "RRC B", 0x8cb, 3 ],
-  [ "RRC C", 0x9cb, 3 ],
-  [ "RRC D", 0xacb, 3 ],
-  [ "RRC E", 0xbcb, 3 ],
-  [ "RRC H", 0xccb, 3 ],
-  [ "RRC [HL]", 0xecb, 3 ],
-  [ "RRC L", 0xdcb, 3 ],
-  [ "RR D", 0x1acb, 3 ],
-  [ "RR E", 0x1bcb, 3 ],
-  [ "RR H", 0x1ccb, 3 ],
-  [ "RR [HL]", 0x1ecb, 3 ],
-  [ "RR L", 0x1dcb, 3 ],
-  [ "RST $0", 0xc7, 0 ],
-  [ "RST $10", 0xd7, 0 ],
-  [ "RST $18", 0xdf, 0 ],
-  [ "RST $20", 0xe7, 0 ],
-  [ "RST $28", 0xef, 0 ],
-  [ "RST $30", 0xf7, 0 ],
-  [ "RST $38", 0xff, 0 ],
-  [ "RST $8", 0xcf, 0 ],
-  [ "SBC A", 0x9f, 0 ],
-  [ "SBC B", 0x98, 0 ],
-  [ "SBC C", 0x99, 0 ],
-  [ "SBC D", 0x9a, 0 ],
-  [ "SBC E", 0x9b, 0 ],
-  [ "SBC H", 0x9c, 0 ],
-  [ "SBC [HL]", 0x9e, 0 ],
-  [ "SBC L", 0x9d, 0 ],
-  [ "SBC x", 0xde, 1 ],
-  [ "SCF", 0x37, 0 ],
-  [ "SET 0, A", 0xc7cb, 3 ],
-  [ "SET 0, B", 0xc0cb, 3 ],
-  [ "SET 0, C", 0xc1cb, 3 ],
-  [ "SET 0, D", 0xc2cb, 3 ],
-  [ "SET 0, E", 0xc3cb, 3 ],
-  [ "SET 0, H", 0xc4cb, 3 ],
-  [ "SET 0, [HL]", 0xc6cb, 3 ],
-  [ "SET 0, L", 0xc5cb, 3 ],
-  [ "SET 1, A", 0xcfcb, 3 ],
-  [ "SET 1, B", 0xc8cb, 3 ],
-  [ "SET 1, C", 0xc9cb, 3 ],
-  [ "SET 1, D", 0xcacb, 3 ],
-  [ "SET 1, E", 0xcbcb, 3 ],
-  [ "SET 1, H", 0xcccb, 3 ],
-  [ "SET 1, [HL]", 0xcecb, 3 ],
-  [ "SET 1, L", 0xcdcb, 3 ],
-  [ "SET 2, A", 0xd7cb, 3 ],
-  [ "SET 2, B", 0xd0cb, 3 ],
-  [ "SET 2, C", 0xd1cb, 3 ],
-  [ "SET 2, D", 0xd2cb, 3 ],
-  [ "SET 2, E", 0xd3cb, 3 ],
-  [ "SET 2, H", 0xd4cb, 3 ],
-  [ "SET 2, [HL]", 0xd6cb, 3 ],
-  [ "SET 2, L", 0xd5cb, 3 ],
-  [ "SET 3, A", 0xdfcb, 3 ],
-  [ "SET 3, B", 0xd8cb, 3 ],
-  [ "SET 3, C", 0xd9cb, 3 ],
-  [ "SET 3, D", 0xdacb, 3 ],
-  [ "SET 3, E", 0xdbcb, 3 ],
-  [ "SET 3, H", 0xdccb, 3 ],
-  [ "SET 3, [HL]", 0xdecb, 3 ],
-  [ "SET 3, L", 0xddcb, 3 ],
-  [ "SET 4, A", 0xe7cb, 3 ],
-  [ "SET 4, B", 0xe0cb, 3 ],
-  [ "SET 4, C", 0xe1cb, 3 ],
-  [ "SET 4, D", 0xe2cb, 3 ],
-  [ "SET 4, E", 0xe3cb, 3 ],
-  [ "SET 4, H", 0xe4cb, 3 ],
-  [ "SET 4, [HL]", 0xe6cb, 3 ],
-  [ "SET 4, L", 0xe5cb, 3 ],
-  [ "SET 5, A", 0xefcb, 3 ],
-  [ "SET 5, B", 0xe8cb, 3 ],
-  [ "SET 5, C", 0xe9cb, 3 ],
-  [ "SET 5, D", 0xeacb, 3 ],
-  [ "SET 5, E", 0xebcb, 3 ],
-  [ "SET 5, H", 0xeccb, 3 ],
-  [ "SET 5, [HL]", 0xeecb, 3 ],
-  [ "SET 5, L", 0xedcb, 3 ],
-  [ "SET 6, A", 0xf7cb, 3 ],
-  [ "SET 6, B", 0xf0cb, 3 ],
-  [ "SET 6, C", 0xf1cb, 3 ],
-  [ "SET 6, D", 0xf2cb, 3 ],
-  [ "SET 6, E", 0xf3cb, 3 ],
-  [ "SET 6, H", 0xf4cb, 3 ],
-  [ "SET 6, [HL]", 0xf6cb, 3 ],
-  [ "SET 6, L", 0xf5cb, 3 ],
-  [ "SET 7, A", 0xffcb, 3 ],
-  [ "SET 7, B", 0xf8cb, 3 ],
-  [ "SET 7, C", 0xf9cb, 3 ],
-  [ "SET 7, D", 0xfacb, 3 ],
-  [ "SET 7, E", 0xfbcb, 3 ],
-  [ "SET 7, H", 0xfccb, 3 ],
-  [ "SET 7, [HL]", 0xfecb, 3 ],
-  [ "SET 7, L", 0xfdcb, 3 ],
-  [ "SLA A", 0x27cb, 3 ],
-  [ "SLA B", 0x20cb, 3 ],
-  [ "SLA C", 0x21cb, 3 ],
-  [ "SLA D", 0x22cb, 3 ],
-  [ "SLA E", 0x23cb, 3 ],
-  [ "SLA H", 0x24cb, 3 ],
-  [ "SLA [HL]", 0x26cb, 3 ],
-  [ "SLA L", 0x25cb, 3 ],
-  [ "SRA A", 0x2fcb, 3 ],
-  [ "SRA B", 0x28cb, 3 ],
-  [ "SRA C", 0x29cb, 3 ],
-  [ "SRA D", 0x2acb, 3 ],
-  [ "SRA E", 0x2bcb, 3 ],
-  [ "SRA H", 0x2ccb, 3 ],
-  [ "SRA [HL]", 0x2ecb, 3 ],
-  [ "SRA L", 0x2dcb, 3 ],
-  [ "SRL A", 0x3fcb, 3 ],
-  [ "SRL B", 0x38cb, 3 ],
-  [ "SRL C", 0x39cb, 3 ],
-  [ "SRL D", 0x3acb, 3 ],
-  [ "SRL E", 0x3bcb, 3 ],
-  [ "SRL H", 0x3ccb, 3 ],
-  [ "SRL [HL]", 0x3ecb, 3 ],
-  [ "SRL L", 0x3dcb, 3 ],
-  [ "STOP", 0x10, 0 ],
-  [ "SUB A", 0x97, 0 ],
-  [ "SUB B", 0x90, 0 ],
-  [ "SUB C", 0x91, 0 ],
-  [ "SUB D", 0x92, 0 ],
-  [ "SUB E", 0x93, 0 ],
-  [ "SUB H", 0x94, 0 ],
-  [ "SUB [HL]", 0x96, 0 ],
-  [ "SUB L", 0x95, 0 ],
-  [ "SUB x", 0xd6, 1 ],
-  [ "SWAP A", 0x37cb, 3 ],
-  [ "SWAP B", 0x30cb, 3 ],
-  [ "SWAP C", 0x31cb, 3 ],
-  [ "SWAP D", 0x32cb, 3 ],
-  [ "SWAP E", 0x33cb, 3 ],
-  [ "SWAP H", 0x34cb, 3 ],
-  [ "SWAP [HL]", 0x36cb, 3 ],
-  [ "SWAP L", 0x35cb, 3 ],
-  [ "XOR A", 0xaf, 0 ],
-  [ "XOR B", 0xa8, 0 ],
-  [ "XOR C", 0xa9, 0 ],
-  [ "XOR D", 0xaa, 0 ],
-  [ "XOR E", 0xab, 0 ],
-  [ "XOR H", 0xac, 0 ],
-  [ "XOR [HL]", 0xae, 0 ],
-  [ "XOR L", 0xad, 0 ],
-  [ "XOR x", 0xee, 1 ],
-  [ "E", 0x100, -1 ],
+z80_table = [
+	('nop', 0),                    # 00
+	('ld bc, {}', 2),              # 01
+	('ld [bc], a', 0),             # 02
+	('inc bc', 0),                 # 03
+	('inc b', 0),                  # 04
+	('dec b', 0),                  # 05
+	('ld b, ${:02x}', 1),          # 06
+	('rlca', 0),                   # 07
+	('ld [{}], sp', 2),            # 08
+	('add hl, bc', 0),             # 09
+	('ld a, [bc]', 0),             # 0a
+	('dec bc', 0),                 # 0b
+	('inc c', 0),                  # 0c
+	('dec c', 0),                  # 0d
+	('ld c, ${:02x}', 1),          # 0e
+	('rrca', 0),                   # 0f
+	('db $10', 0),                 # 10
+	('ld de, {}', 2),              # 11
+	('ld [de], a', 0),             # 12
+	('inc de', 0),                 # 13
+	('inc d', 0),                  # 14
+	('dec d', 0),                  # 15
+	('ld d, ${:02x}', 1),          # 16
+	('rla', 0),                    # 17
+	('jr {}', 1),                  # 18
+	('add hl, de', 0),             # 19
+	('ld a, [de]', 0),             # 1a
+	('dec de', 0),                 # 1b
+	('inc e', 0),                  # 1c
+	('dec e', 0),                  # 1d
+	('ld e, ${:02x}', 1),          # 1e
+	('rra', 0),                    # 1f
+	('jr nz, {}', 1),              # 20
+	('ld hl, {}', 2),              # 21
+	('ld [hli], a', 0),            # 22
+	('inc hl', 0),                 # 23
+	('inc h', 0),                  # 24
+	('dec h', 0),                  # 25
+	('ld h, ${:02x}', 1),          # 26
+	('daa', 0),                    # 27
+	('jr z, {}', 1),               # 28
+	('add hl, hl', 0),             # 29
+	('ld a, [hli]', 0),            # 2a
+	('dec hl', 0),                 # 2b
+	('inc l', 0),                  # 2c
+	('dec l', 0),                  # 2d
+	('ld l, ${:02x}', 1),          # 2e
+	('cpl', 0),                    # 2f
+	('jr nc, {}', 1),              # 30
+	('ld sp, {}', 2),              # 31
+	('ld [hld], a', 0),            # 32
+	('inc sp', 0),                 # 33
+	('inc [hl]', 0),               # 34
+	('dec [hl]', 0),               # 35
+	('ld [hl], ${:02x}', 1),       # 36
+	('scf', 0),                    # 37
+	('jr c, {}', 1),               # 38
+	('add hl, sp', 0),             # 39
+	('ld a, [hld]', 0),            # 3a
+	('dec sp', 0),                 # 3b
+	('inc a', 0),                  # 3c
+	('dec a', 0),                  # 3d
+	('ld a, ${:02x}', 1),          # 3e
+	('ccf', 0),                    # 3f
+	('ld b, b', 0),                # 40
+	('ld b, c', 0),                # 41
+	('ld b, d', 0),                # 42
+	('ld b, e', 0),                # 43
+	('ld b, h', 0),                # 44
+	('ld b, l', 0),                # 45
+	('ld b, [hl]', 0),             # 46
+	('ld b, a', 0),                # 47
+	('ld c, b', 0),                # 48
+	('ld c, c', 0),                # 49
+	('ld c, d', 0),                # 4a
+	('ld c, e', 0),                # 4b
+	('ld c, h', 0),                # 4c
+	('ld c, l', 0),                # 4d
+	('ld c, [hl]', 0),             # 4e
+	('ld c, a', 0),                # 4f
+	('ld d, b', 0),                # 50
+	('ld d, c', 0),                # 51
+	('ld d, d', 0),                # 52
+	('ld d, e', 0),                # 53
+	('ld d, h', 0),                # 54
+	('ld d, l', 0),                # 55
+	('ld d, [hl]', 0),             # 56
+	('ld d, a', 0),                # 57
+	('ld e, b', 0),                # 58
+	('ld e, c', 0),                # 59
+	('ld e, d', 0),                # 5a
+	('ld e, e', 0),                # 5b
+	('ld e, h', 0),                # 5c
+	('ld e, l', 0),                # 5d
+	('ld e, [hl]', 0),             # 5e
+	('ld e, a', 0),                # 5f
+	('ld h, b', 0),                # 60
+	('ld h, c', 0),                # 61
+	('ld h, d', 0),                # 62
+	('ld h, e', 0),                # 63
+	('ld h, h', 0),                # 64
+	('ld h, l', 0),                # 65
+	('ld h, [hl]', 0),             # 66
+	('ld h, a', 0),                # 67
+	('ld l, b', 0),                # 68
+	('ld l, c', 0),                # 69
+	('ld l, d', 0),                # 6a
+	('ld l, e', 0),                # 6b
+	('ld l, h', 0),                # 6c
+	('ld l, l', 0),                # 6d
+	('ld l, [hl]', 0),             # 6e
+	('ld l, a', 0),                # 6f
+	('ld [hl], b', 0),             # 70
+	('ld [hl], c', 0),             # 71
+	('ld [hl], d', 0),             # 72
+	('ld [hl], e', 0),             # 73
+	('ld [hl], h', 0),             # 74
+	('ld [hl], l', 0),             # 75
+	('halt', 0),                   # 76
+	('ld [hl], a', 0),             # 77
+	('ld a, b', 0),                # 78
+	('ld a, c', 0),                # 79
+	('ld a, d', 0),                # 7a
+	('ld a, e', 0),                # 7b
+	('ld a, h', 0),                # 7c
+	('ld a, l', 0),                # 7d
+	('ld a, [hl]', 0),             # 7e
+	('ld a, a', 0),                # 7f
+	('add b', 0),                  # 80
+	('add c', 0),                  # 81
+	('add d', 0),                  # 82
+	('add e', 0),                  # 83
+	('add h', 0),                  # 84
+	('add l', 0),                  # 85
+	('add [hl]', 0),               # 86
+	('add a', 0),                  # 87
+	('adc b', 0),                  # 88
+	('adc c', 0),                  # 89
+	('adc d', 0),                  # 8a
+	('adc e', 0),                  # 8b
+	('adc h', 0),                  # 8c
+	('adc l', 0),                  # 8d
+	('adc [hl]', 0),               # 8e
+	('adc a', 0),                  # 8f
+	('sub b', 0),                  # 90
+	('sub c', 0),                  # 91
+	('sub d', 0),                  # 92
+	('sub e', 0),                  # 93
+	('sub h', 0),                  # 94
+	('sub l', 0),                  # 95
+	('sub [hl]', 0),               # 96
+	('sub a', 0),                  # 97
+	('sbc b', 0),                  # 98
+	('sbc c', 0),                  # 99
+	('sbc d', 0),                  # 9a
+	('sbc e', 0),                  # 9b
+	('sbc h', 0),                  # 9c
+	('sbc l', 0),                  # 9d
+	('sbc [hl]', 0),               # 9e
+	('sbc a', 0),                  # 9f
+	('and b', 0),                  # a0
+	('and c', 0),                  # a1
+	('and d', 0),                  # a2
+	('and e', 0),                  # a3
+	('and h', 0),                  # a4
+	('and l', 0),                  # a5
+	('and [hl]', 0),               # a6
+	('and a', 0),                  # a7
+	('xor b', 0),                  # a8
+	('xor c', 0),                  # a9
+	('xor d', 0),                  # aa
+	('xor e', 0),                  # ab
+	('xor h', 0),                  # ac
+	('xor l', 0),                  # ad
+	('xor [hl]', 0),               # ae
+	('xor a', 0),                  # af
+	('or b', 0),                   # b0
+	('or c', 0),                   # b1
+	('or d', 0),                   # b2
+	('or e', 0),                   # b3
+	('or h', 0),                   # b4
+	('or l', 0),                   # b5
+	('or [hl]', 0),                # b6
+	('or a', 0),                   # b7
+	('cp b', 0),                   # b8
+	('cp c', 0),                   # b9
+	('cp d', 0),                   # ba
+	('cp e', 0),                   # bb
+	('cp h', 0),                   # bc
+	('cp l', 0),                   # bd
+	('cp [hl]', 0),                # be
+	('cp a', 0),                   # bf
+	('ret nz', 0),                 # c0
+	('pop bc', 0),                 # c1
+	('jp nz, {}', 2),              # c2
+	('jp {}', 2),                  # c3
+	('call nz, {}', 2),            # c4
+	('push bc', 0),                # c5
+	('add ${:02x}', 1),            # c6
+	('rst $0', 0),                 # c7
+	('ret z', 0),                  # c8
+	('ret', 0),                    # c9
+	('jp z, {}', 2),               # ca
+	('bitops', 1),                 # cb
+	('call z, {}', 2),             # cc
+	('call {}', 2),                # cd
+	('adc ${:02x}', 1),            # ce
+	('rst $8', 0),                 # cf
+	('ret nc', 0),                 # d0
+	('pop de', 0),                 # d1
+	('jp nc, ${:04x}', 2),         # d2
+	('db $d3', 0),                 # d3
+	('call nc, {}', 2),            # d4
+	('push de', 0),                # d5
+	('sub ${:02x}', 1),            # d6
+	('rst $10', 0),                # d7
+	('ret c', 0),                  # d8
+	('reti', 0),                   # d9
+	('jp c, ${:04x}', 2),          # da
+	('db $db', 0),                 # db
+	('call c, {}', 2),             # dc
+	('db $dd', 2),                 # dd
+	('sbc ${:02x}', 1),            # de
+	('rst $18', 0),                # df
+	('ld [{}], a', 1),             # e0
+	('pop hl', 0),                 # e1
+	('ld [$ff00+c], a', 0),        # e2
+	('db $e3', 0),                 # e3
+	('db $e4', 0),                 # e4
+	('push hl', 0),                # e5
+	('and ${:02x}', 1),            # e6
+	('rst $20', 0),                # e7
+	('add sp, ${:02x}', 1),        # e8
+	('jp [hl]', 0),                # e9
+	('ld [{}], a', 2),             # ea
+	('db $eb', 0),                 # eb
+	('db $ec', 2),                 # ec
+	('db $ed', 2),                 # ed
+	('xor ${:02x}', 1),            # ee
+	('rst $28', 0),                # ef
+	('ld a, [{}]', 1),             # f0
+	('pop af', 0),                 # f1
+	('db $f2', 0),                 # f2
+	('di', 0),                     # f3
+	('db $f4', 0),                 # f4
+	('push af', 0),                # f5
+	('or ${:02x}', 1),             # f6
+	('rst $30', 0),                # f7
+	('ld hl, sp+${:02x}', 1),      # f8
+	('ld sp, [hl]', 0),            # f9
+	('ld a, [{}]', 2),             # fa
+	('ei', 0),                     # fb
+	('db $fc', 2),                 # fc
+	('db $fd', 2),                 # fd
+	('cp ${:02x}', 1),             # fe
+	('rst $38', 0),                # ff
+]
+ 
+bit_ops_table = [
+	"rlc b",     "rlc c",     "rlc d",     "rlc e",     "rlc h",     "rlc l",     "rlc [hl]",     "rlc a",       # $00 - $07
+	"rrc b",     "rrc c",     "rrc d",     "rrc e",     "rrc h",     "rrc l",     "rrc [hl]",     "rrc a",       # $08 - $0f
+	"rl b",      "rl c",      "rl d",      "rl e",      "rl h",      "rl l",      "rl [hl]",      "rl a",        # $10 - $17
+	"rr b",      "rr c",      "rr d",      "rr e",      "rr h",      "rr l",      "rr [hl]",      "rr a",        # $18 - $1f
+	"sla b",     "sla c",     "sla d",     "sla e",     "sla h",     "sla l",     "sla [hl]",     "sla a",       # $20 - $27
+	"sra b",     "sra c",     "sra d",     "sra e",     "sra h",     "sra l",     "sra [hl]",     "sra a",       # $28 - $2f
+	"swap b",    "swap c",    "swap d",    "swap e",    "swap h",    "swap l",    "swap [hl]",    "swap a",      # $30 - $37
+	"srl b",     "srl c",     "srl d",     "srl e",     "srl h",     "srl l",     "srl [hl]",     "srl a",       # $38 - $3f
+	"bit 0, b",  "bit 0, c",  "bit 0, d",  "bit 0, e",  "bit 0, h",  "bit 0, l",  "bit 0, [hl]",  "bit 0, a",    # $40 - $47
+	"bit 1, b",  "bit 1, c",  "bit 1, d",  "bit 1, e",  "bit 1, h",  "bit 1, l",  "bit 1, [hl]",  "bit 1, a",    # $48 - $4f
+	"bit 2, b",  "bit 2, c",  "bit 2, d",  "bit 2, e",  "bit 2, h",  "bit 2, l",  "bit 2, [hl]",  "bit 2, a",    # $50 - $57
+	"bit 3, b",  "bit 3, c",  "bit 3, d",  "bit 3, e",  "bit 3, h",  "bit 3, l",  "bit 3, [hl]",  "bit 3, a",    # $58 - $5f
+	"bit 4, b",  "bit 4, c",  "bit 4, d",  "bit 4, e",  "bit 4, h",  "bit 4, l",  "bit 4, [hl]",  "bit 4, a",    # $60 - $67
+	"bit 5, b",  "bit 5, c",  "bit 5, d",  "bit 5, e",  "bit 5, h",  "bit 5, l",  "bit 5, [hl]",  "bit 5, a",    # $68 - $6f
+	"bit 6, b",  "bit 6, c",  "bit 6, d",  "bit 6, e",  "bit 6, h",  "bit 6, l",  "bit 6, [hl]",  "bit 6, a",    # $70 - $77
+	"bit 7, b",  "bit 7, c",  "bit 7, d",  "bit 7, e",  "bit 7, h",  "bit 7, l",  "bit 7, [hl]",  "bit 7, a",    # $78 - $7f
+	"res 0, b",  "res 0, c",  "res 0, d",  "res 0, e",  "res 0, h",  "res 0, l",  "res 0, [hl]",  "res 0, a",    # $80 - $87
+	"res 1, b",  "res 1, c",  "res 1, d",  "res 1, e",  "res 1, h",  "res 1, l",  "res 1, [hl]",  "res 1, a",    # $88 - $8f
+	"res 2, b",  "res 2, c",  "res 2, d",  "res 2, e",  "res 2, h",  "res 2, l",  "res 2, [hl]",  "res 2, a",    # $90 - $97
+	"res 3, b",  "res 3, c",  "res 3, d",  "res 3, e",  "res 3, h",  "res 3, l",  "res 3, [hl]",  "res 3, a",    # $98 - $9f
+	"res 4, b",  "res 4, c",  "res 4, d",  "res 4, e",  "res 4, h",  "res 4, l",  "res 4, [hl]",  "res 4, a",    # $a0 - $a7
+	"res 5, b",  "res 5, c",  "res 5, d",  "res 5, e",  "res 5, h",  "res 5, l",  "res 5, [hl]",  "res 5, a",    # $a8 - $af
+	"res 6, b",  "res 6, c",  "res 6, d",  "res 6, e",  "res 6, h",  "res 6, l",  "res 6, [hl]",  "res 6, a",    # $b0 - $b7
+	"res 7, b",  "res 7, c",  "res 7, d",  "res 7, e",  "res 7, h",  "res 7, l",  "res 7, [hl]",  "res 7, a",    # $b8 - $bf
+	"set 0, b",  "set 0, c",  "set 0, d",  "set 0, e",  "set 0, h",  "set 0, l",  "set 0, [hl]",  "set 0, a",    # $c0 - $c7
+	"set 1, b",  "set 1, c",  "set 1, d",  "set 1, e",  "set 1, h",  "set 1, l",  "set 1, [hl]",  "set 1, a",    # $c8 - $cf
+	"set 2, b",  "set 2, c",  "set 2, d",  "set 2, e",  "set 2, h",  "set 2, l",  "set 2, [hl]",  "set 2, a",    # $d0 - $d7
+	"set 3, b",  "set 3, c",  "set 3, d",  "set 3, e",  "set 3, h",  "set 3, l",  "set 3, [hl]",  "set 3, a",    # $d8 - $df
+	"set 4, b",  "set 4, c",  "set 4, d",  "set 4, e",  "set 4, h",  "set 4, l",  "set 4, [hl]",  "set 4, a",    # $e0 - $e7
+	"set 5, b",  "set 5, c",  "set 5, d",  "set 5, e",  "set 5, h",  "set 5, l",  "set 5, [hl]",  "set 5, a",    # $e8 - $ef
+	"set 6, b",  "set 6, c",  "set 6, d",  "set 6, e",  "set 6, h",  "set 6, l",  "set 6, [hl]",  "set 6, a",    # $f0 - $f7
+	"set 7, b",  "set 7, c",  "set 7, d",  "set 7, e",  "set 7, h",  "set 7, l",  "set 7, [hl]",  "set 7, a"     # $f8 - $ff
 ]
 
-# construct a more useful version of opt_table
-opt_table = {}
-for line in temp_opt_table:
-    opt_table[line[1]] = [line[0], line[2]]
-del line
+unconditional_returns = [0xc9, 0xd9]
+absolute_jumps = [0xc3, 0xc2, 0xca, 0xd2, 0xda]
+call_commands = [0xcd, 0xc4, 0xcc, 0xd4, 0xdc]
+relative_jumps = [0x18, 0x20, 0x28, 0x30, 0x38]
+unconditional_jumps = [0xc3, 0x18]
 
-end_08_scripts_with = [
-0xc9, #ret
-0xd9, #reti
-0xe9, #jp hl
-#0xc3, #jp
-##0x18, #jr
-###0xda, 0xe9, 0xd2, 0xc2, 0xca, 0xc3, 0x38, 0x30, 0x20, 0x28, 0x18, 0xd8, 0xd0, 0xc0, 0xc8, 0xc9
-]
-
-discrete_jumps = [0xda, 0xe9, 0xd2, 0xc2, 0xca, 0xc3]
-relative_jumps = [0x38, 0x30, 0x20, 0x28, 0x18, 0xc3, 0xda, 0xc2]
-relative_unconditional_jumps = [0xc3, 0x18]
-
-call_commands = [0xdc, 0xd4, 0xc4, 0xcc, 0xcd]
 
 def asm_label(address):
-    """
-    Return a local label name for asm at <address>.
-    """
-    return '.asm_%x' % address
+	"""
+	Return a local label name for asm at <address>.
+	"""
+	return '.asm_%x' % address
 
 def data_label(address):
-    """
-    Return a local label name for data at <address>.
-    """
-    return '.data_%x' % address
+	"""
+	Return a local label name for data at <address>.
+	"""
+	return '.data_%x' % address
 
 def get_local_address(address):
-    """
-    Return the local address of a rom address.
-    """
-    bank = address / 0x4000
-    address &= 0x3fff
-    if bank:
-        return address + 0x4000
-    return address
+	"""
+	Return the local address of a rom address.
+	"""
+	bank = address / 0x4000
+	address &= 0x3fff
+	if bank:
+		return address + 0x4000
+	return address
 
 def get_global_address(address, bank):
-    """
-    Return the rom address of a local address and bank.
+	"""
+	Return the rom address of a local address and bank.
 
-    This accounts for a quirk in mbc3+ where 0:4000-7fff resolves to 1:4000-7fff.
-    """
-    if address < 0x8000:
-        if address >= 0x4000 and bank > 0:
-            return address + (bank - 1) * 0x4000
-        return address
-    return None
+	This accounts for a quirk in mbc3 where 0:4000-7fff resolves to 1:4000-7fff.
+	"""
+	if address < 0x8000:
+		if address >= 0x4000 and bank > 0:
+			return address + (bank - 1) * 0x4000
+	
+	return address
 
-def has_outstanding_labels(byte_labels):
-    """
-    Check whether a label is used once in the asm output.
+def created_but_unused_labels_exist(byte_labels):
+	"""
+	Check whether a label has been created but not used.
 
-    If so, then that means it has to be called or specified later.
-    """
-    for label_line in byte_labels.keys():
-        real_line = byte_labels[label_line]
-        if real_line["definition"] == False: return True
-    return False
+	If so, then that means it has to be called or specified later.
+	"""
+	return (False in [label["definition"] for label in byte_labels.values()])
 
-def all_outstanding_labels_are_reverse(byte_labels, offset):
-    """
-    Check whether all labels have already been defined.
-    """
-    for label_id in byte_labels.keys():
-        line = byte_labels[label_id] # label_id is also the address
-        if line["definition"] == False:
-            if not label_id < offset: return False
-    return True
+def all_byte_labels_are_defined(byte_labels):
+	"""
+	Check whether all labels have already been defined.
+	"""
+	return (False not in [label["definition"] for label in byte_labels.values()])
 
 def load_rom(path='baserom.gbc'):
-    return bytearray(open(path, 'rb').read())
+	return bytearray(open(path, 'rb').read())
 
 def read_symfile(path='baserom.sym'):
-    """
-    Return a list of dicts of label data from an rgbds .sym file.
-    """
-    symbols = []
-    for line in open(path):
-        line = line.strip().split(';')[0]
-        if line:
-            bank_address, label = line.split(' ')[:2]
-            bank, address = bank_address.split(':')
-            symbols += [{
-                'label': label,
-                'bank': int(bank, 16),
-                'address': int(address, 16),
-            }]
-    return symbols
+	"""
+	Return a list of dicts of label data from an rgbds .sym file.
+	"""
+	symbols = []
+	for line in open(path):
+		line = line.strip().split(';')[0]
+		if line:
+			bank_address, label = line.split(' ')[:2]
+			bank, address = bank_address.split(':')
+			symbols += [{
+				'label': label,
+				'bank': int(bank, 16),
+				'address': int(address, 16),
+			}]
+	return symbols
 
 def load_symbols(path):
-    sym = {}
-    reverse_sym = {}
-    symbols = read_symfile(path)
-    for symbol in symbols:
-        bank = symbol['bank']
-        address = symbol['address']
-        label = symbol['label']
-        if not sym.has_key(bank):
-            sym[bank] = {}
-        sym[bank][address] = label
-        reverse_sym[label] = get_global_address(address, bank)
-    return sym, reverse_sym
+	sym = {}
+	reverse_sym = {}
+	wram_sym = {}
+	sram_sym = {}
+	
+	symbols = read_symfile(path)
+	for symbol in symbols:
+		bank = symbol['bank']
+		address = symbol['address']
+		label = symbol['label']
+		
+		if 0x0000 <= address < 0x8000:
+			if not sym.has_key(bank):
+				sym[bank] = {}
+			
+			sym[bank][address] = label
+			reverse_sym[label] = get_global_address(address, bank)
+			
+		elif 0xa000 <= address < 0xc000:
+			if not sram_sym.has_key(bank):
+				sram_sym[bank] = {}
+				
+			sram_sym[bank][address] = label
+			
+		elif address < 0xe000:
+			if not wram_sym.has_key(bank):
+				wram_sym[bank] = {}
+			
+			wram_sym[bank][address] = label
+		else:	
+			raise ValueError("Unsupported symfile label type.")
+		
+	return sym, reverse_sym, wram_sym, sram_sym
 
 def get_symbol(sym, address, bank=0):
-    if sym:
-        return sym.get(bank, {}).get(address)
-    return None
+	if sym:
+		if 0x0000 <= address < 0x4000:
+			return sym.get(0, {}).get(address)
+		else:
+			return sym.get(bank, {}).get(address)
+	
+	return None
+
+def get_banked_ram_sym(sym, address):
+	#if sym:
+	#	if 0xc000 <= address < 0xd000:
+	#		return sym.get(0, {}).get(address)
+	#	else:
+	#		return sym.get(bank, {}).get(address)
+	if sym:
+		for bank in sym.keys():
+			temp_sym = sym.get(bank, {}).get(address)
+			if temp_sym:
+				return temp_sym
+		
+	return None
+
+def create_address_comment(offset):
+	comment_bank = offset / 0x4000
+	if comment_bank != 0:
+		comment_bank_addr = (offset % 0x4000) + 0x4000
+	else:
+		comment_bank_addr = offset
+		
+	return " ; %x (%x:%x)" % (offset, comment_bank, comment_bank_addr)
+			
+def offset_is_used(labels, offset):
+	if offset in labels.keys():
+		return 0 < labels[offset]["usage"]
 
 class Disassembler(object):
-    """
-    GBC disassembler
-    """
+	"""
+	GBC disassembler
+	"""
 
-    def __init__(self, config):
-        """
-        Setup the class instance.
-        """
-        self.config = config
-        self.spacing = '\t'
-        self.rom = None
-        self.sym = None
-        self.rsym = None
-        self.gbhw = None
+	def __init__(self, config):
+		"""
+		Setup the class instance.
+		"""
+		self.config = config
+		self.spacing = '\t'
+		self.rom = None
+		self.sym = None
+		self.rsym = None
+		self.gbhw = None
+		self.vram = None
+		self.sram = None
+		self.hram = None
+		self.wram = None
 
-    def initialize(self):
-        """
-        Setup the disassembler.
-        """
-        path = os.path.join(self.config.path, 'baserom.gbc')
-        self.rom = load_rom(path)
+	def initialize(self, rom, symfile):
+		"""
+		Setup the disassembler.
+		"""
+		path = os.path.join(self.config.path, rom)
+		self.rom = load_rom(path)
+		
+		path = os.path.join(self.config.path, symfile)
+		if os.path.exists(path):
+			self.sym, self.rsym, self.wram, self.sram = load_symbols(path)
 
-        path = os.path.join(self.config.path, 'baserom.sym')
-        if os.path.exists(path):
-            self.sym, self.rsym = load_symbols(path)
+		path = os.path.join(self.config.path, 'gbhw.asm')
+		
+		if os.path.exists(path):
+			self.gbhw = read_constants(path)
+		else:
+			path = os.path.join(self.config.path, "constants/hardware_constants.asm")
+			if os.path.exists(path):
+				self.gbhw = read_constants(path)
+		
+		path = os.path.join(self.config.path, 'vram.asm')
+		if os.path.exists(path):
+			self.vram = read_constants(path)
+			
+		path = os.path.join(self.config.path, 'hram.asm')
+		if os.path.exists(path):
+			self.hram = read_constants(path)
 
-        path = os.path.join(self.config.path, 'gbhw.asm')
-        if os.path.exists(path):
-            self.gbhw = read_constants(path)
+	def find_label(self, address, bank=0):
+		if type(address) is str:
+			address = int(address.replace('$', '0x'), 16)
+		elif address is None:
+			return address
+		
+		if 0x0000 <= address < 0x8000:
+			label = self.get_symbol(address, bank)
+		elif address < 0xa000 and self.vram:
+			label = self.vram.get(address)
+		elif address < 0xc000:
+			label = self.get_sram(address)
+		elif address < 0xe000:
+			label = self.get_wram(address)
+		elif ((0xff00 <= address < 0xff80) or (address == 0xffff)) and self.gbhw:
+			label = self.gbhw.get(address)
+		elif (0xff80 <= address < 0xffff) and self.hram:
+			label = self.hram.get(address)
+		else:
+			label = None
+			
+		return label
 
-    def find_label(self, address, bank=0):
-        if type(address) is not int:
-            address = int(address.replace('$', '0x'), 16)
-        label = self.get_symbol(address, bank)
-        if not label:
-            label = self.get_gbhw(address)
-        return label
+	def get_symbol(self, address, bank):
+		symbol = get_symbol(self.sym, address, bank)
+		if symbol == 'NULL' and address == 0 and bank == 0:
+			return None
+		return symbol
 
-    def get_symbol(self, address, bank):
-        symbol = get_symbol(self.sym, address, bank)
-        if symbol == 'NULL' and address == 0 and bank == 0:
-            return None
-        return symbol
+	def get_wram(self, address):
+		symbol = get_banked_ram_sym(self.wram, address)
+		if symbol == 'NULL' and address == 0:
+			return None
+		return symbol
+		
+	def get_sram(self, address):
+		symbol = get_banked_ram_sym(self.sram, address)
+		if symbol == 'NULL' and address == 0:
+			return None
+		return symbol
+		
+	def find_address_from_label(self, label):
+		if self.rsym:
+			return self.rsym.get(label)
+		
+		return None
 
-    def get_gbhw(self, address):
-        if 0xff00 <= address < 0xff80:
-            if self.gbhw:
-                return self.gbhw.get(address)
-        return None
+	def output_bank_opcodes(self, start_offset, stop_offset, hard_stop=False, parse_data=False, include_last_address=True):
+		"""
+		Output bank opcodes.
 
-    def find_address_from_label(self, label):
-        if self.rsym:
-            return self.rsym.get(label)
-        return None
+		fs = current_address
+		b = bank_byte
+		in = input_data  -- rom
+		bank_size = byte_count
+		i = offset
+		ad = end_address
+		a, oa = current_byte_number
 
-    def output_bank_opcodes(self, original_offset, max_byte_count=0x4000, include_last_address=True, stop_at=[], debug=False):
-        """
-        Output bank opcodes.
+		stop_at can be used to supply a list of addresses to not disassemble
+		over. This is useful if you know in advance that there are a lot of
+		fall-throughs.
+		"""
+		
+		debug = False
+				
+		bank_id = start_offset / 0x4000
+		
+		stop_offset_undefined = False
+		
+		# check if stop_offset isn't defined
+		if stop_offset is None:
+			stop_offset_undefined = True
+			# stop at the end of the current bank if stop_offset is not defined
+			stop_offset = (bank_id + 1) * 0x4000 - 1
+	
+		if debug:
+			print "bank id is: " + str(bank_id)
 
-        fs = current_address
-        b = bank_byte
-        in = input_data  -- rom
-        bank_size = byte_count
-        i = offset
-        ad = end_address
-        a, oa = current_byte_number
+		rom = self.rom
 
-        stop_at can be used to supply a list of addresses to not disassemble
-        over. This is useful if you know in advance that there are a lot of
-        fall-throughs.
-        """
+		offset = start_offset
+		current_byte_number = 0 #start from the beginning		
 
-        bank_id = original_offset / 0x4000
-        if debug: print "bank id is: " + str(bank_id)
+		byte_labels = {}
+		data_tables = {}
+		
+		output = "Func_%x:%s\n" % (start_offset,create_address_comment(start_offset))
+		is_data = False
+		
+		while True:
+			#first check if this byte already has a label
+			#if it does, use the label
+			#if not, generate a new label
+			
+			local_offset = get_local_address(offset)
+			
+			data_label_used = offset_is_used(data_tables, local_offset)
+			byte_label_used = offset_is_used(byte_labels, local_offset)
+			data_label_created = local_offset in data_tables.keys()
+			byte_label_created = local_offset in byte_labels.keys()
+			
+			if byte_label_created:
+			# if a byte label exists, remove any significance if there is a data label that exists
+				if data_label_created:
+					data_line_label = data_tables[local_offset]["name"]
+					data_tables[local_offset]["usage"] = 0
+				else:
+					data_line_label = data_label(offset)
+					data_tables[local_offset] = {}
+					data_tables[local_offset]["name"] = data_line_label
+					data_tables[local_offset]["usage"] = 0
+					
+				line_label = byte_labels[local_offset]["name"]
+				byte_labels[local_offset]["usage"] += 1
+				output += "\n"
+			elif data_label_created and parse_data:
+			# go add usage to a data label if it exists
+				data_line_label = data_tables[local_offset]["name"]
+				data_tables[local_offset]["usage"] += 1
+				
+				line_label = asm_label(offset)
+				byte_labels[local_offset] = {}
+				byte_labels[local_offset]["name"] = line_label
+				byte_labels[local_offset]["usage"] = 0
+				output += "\n"
+			else:
+			# create both a data and byte label if neither exist
+				data_line_label = data_label(offset)
+				data_tables[local_offset] = {}
+				data_tables[local_offset]["name"] = data_line_label
+				data_tables[local_offset]["usage"] = 0
+					
+				line_label = asm_label(offset)
+				byte_labels[local_offset] = {}
+				byte_labels[local_offset]["name"] = line_label
+				byte_labels[local_offset]["usage"] = 0
 
-        last_hl_address = None #for when we're scanning the main map script
-        last_a_address = None
-        used_3d97 = False
+			# any labels created not above are now used, so mark them as "defined"
+			byte_labels[local_offset]["definition"] = True
+			data_tables[local_offset]["definition"] = True
+			
+			# for now, output the byte and data labels (unused labels will be removed later
+			output += line_label + "\n" + data_line_label + "\n"
+			
+			# get the current byte
+			opcode_byte = rom[offset]
+			
+			# process the current byte if this is code or parse data has not been set
+			if not is_data or not parse_data:
+				# fetch the opcode string from a predefined table
+				opcode_str = z80_table[opcode_byte][0]
+				# fetch the number of arguments
+				opcode_nargs = z80_table[opcode_byte][1]
+				# get opcode arguments in advance (may not be used)
+				opcode_arg_1 = rom[offset+1]
+				opcode_arg_2 = rom[offset+2]
+				
+				if opcode_nargs == 0:
+				# set output string simply as the opcode
+					opcode_output_str = opcode_str
+				
+				elif opcode_nargs == 1:
+				# opcodes with 1 argument
+					if opcode_byte != 0xcb: # bit opcodes are handled separately
+						
+						if opcode_byte in relative_jumps:
+						# if the current opcode is a relative jump, generate a label for the address we're jumping to
+							# get the address of the location to jump to
+							target_address = offset + 2 + c_int8(opcode_arg_1).value
+							# get the local address to use as a key for byte_labels and data_tables
+							local_target_address = get_local_address(target_address)
+							
+							if local_target_address in byte_labels.keys():
+							# if the label has already been created, increase the usage and set output to the already created label
+								byte_labels[local_target_address]["usage"] += 1
+								opcode_output_str = byte_labels[local_target_address]["name"]
+							elif target_address < start_offset:
+							# if we're jumping to an address that is located before the start offset, assume it is a function
+								opcode_output_str = "Func_%x" % target_address
+							else:
+							# create a new label
+								opcode_output_str = asm_label(target_address)
+								byte_labels[local_target_address] = {}
+								byte_labels[local_target_address]["name"] = opcode_output_str
+								# we know the label is used once, so set the usage to 1
+								byte_labels[local_target_address]["usage"] = 1
+								# since the label has not been output yet, mark it as "not defined"
+								byte_labels[local_target_address]["definition"] = False
+							
+							# check if the target address conflicts with any data labels
+							if local_target_address in data_tables.keys():
+								# if so, remove any instances of it being used and set it as defined
+								data_tables[local_target_address]["usage"] = 0
+								data_tables[local_target_address]["definition"] = True
+							
+							# format the resulting argument into the output string
+							opcode_output_str = opcode_str.format(opcode_output_str)
+							
+							# debug function
+							if created_but_unused_labels_exist(byte_labels) and debug:
+								output += create_address_comment(offset)
+						
+						elif opcode_byte == 0xe0 or opcode_byte == 0xf0:
+						# handle gameboy hram read/write opcodes
+							# create the address
+							high_ram_address = 0xff00 + opcode_arg_1
+							# search for an hram constant if possible
+							high_ram_label = self.find_label(high_ram_address, bank_id)
+							# if we couldn't find one, default to the address
+							if high_ram_label is None:
+								high_ram_label = "$%x" % high_ram_address
+							
+							# format the resulting argument into the output string
+							opcode_output_str = opcode_str.format(high_ram_label)
+						
+						else:
+						# if this isn't a relative jump or hram read/write, just format the byte into the opcode string
+							opcode_output_str = opcode_str.format(opcode_arg_1)
+					
+					else:
+					# handle bit opcodes by fetching the opcode from a separate table
+						opcode_output_str = bit_ops_table[opcode_arg_1]
+				
+				elif opcode_nargs == 2:
+				# opcodes with a pointer as an argument
+					# format the two arguments into a little endian 16-bit pointer
+					local_target_offset = opcode_arg_2 << 8 | opcode_arg_1
+					# get the global offset of the pointer
+					target_offset = get_global_address(local_target_offset, bank_id)
+					# attempt to look for a matching label
+					target_label = self.find_label(target_offset, bank_id)
+					
+					if opcode_byte in call_commands + absolute_jumps:
+						if target_label is None:
+						# if this is a call or jump opcode and the target label is not defined, create an undocumented label descriptor
+							target_label = "Func_%x" % target_offset
 
-        rom = self.rom
+					else:
+					# anything that isn't a call or jump is a load-based command
+						if target_label is None:
+						# handle the case of a label for the current address not existing
+						
+							# first, check if this is a byte label
+							if offset_is_used(byte_labels, local_target_offset):
+								# fetch the already created byte label
+								target_label = byte_labels[local_target_offset]["name"]
+								# prevent this address from being treated as a data label
+								if local_target_offset in data_tables.keys():
+									data_tables[local_target_offset]["usage"] = 0
+								else:
+									data_tables[local_target_offset] = {}
+									data_tables[local_target_offset]["name"] = target_label
+									data_tables[local_target_offset]["usage"] = 0
+									data_tables[local_target_offset]["definition"] = True
+									
+							elif local_target_offset >= 0x8000 or not parse_data:
+							# do not create a label if this is a wram label or parse_data is not set
+								target_label = "$%x" % local_target_offset
+							
+							elif local_target_offset in data_tables.keys():
+							# if the target offset has been created as a data label, increase usage and use the already defined name
+								data_tables[local_target_offset]["usage"] += 1
+								target_label = data_tables[local_target_offset]["name"]	
+							else:
+							# for now, treat this as a data label, but do not set it as used (will be replaced later if unused)
+								target_label = data_label(target_offset)
+								data_tables[local_target_offset] = {}
+								data_tables[local_target_offset]["name"] = target_label
+								data_tables[local_target_offset]["usage"] = 0
+								data_tables[local_target_offset]["definition"] = False
+							
+					# format the label that was created into the opcode string
+					opcode_output_str = opcode_str.format(target_label)	
 
-        offset = original_offset
-        current_byte_number = 0 #start from the beginning
+				else:
+					# error checking
+					raise ValueError("Invalid amount of args.")
+				
+				# append the formatted opcode output string to the output
+				output += self.spacing + opcode_output_str + "\n" #+ " ; " + hex(offset)
+				# increase the current byte number and offset by the amount of arguments plus 1 (opcode itself)
+				current_byte_number += opcode_nargs + 1
+				offset += opcode_nargs + 1
+				
+			else:
+				# output a single lined db, using the current byte
+				output += self.spacing + "db ${:02x}\n".format(opcode_byte) #+ " ; " + hex(offset)
+				# manually increment offset and current byte number
+				offset += 1
+				current_byte_number += 1
+				# stop treating the current code as data if we're parsing over a byte label
+				if get_local_address(offset) in byte_labels.keys():
+					is_data = False
+			
+			# update the local offset
+			local_offset = get_local_address(offset)
+			
+			# stop processing regardless of function end if we've passed the stop offset and the hard stop (dry run) flag is set
+			if hard_stop and offset >= stop_offset:
+				break
+			# check if this is the end of the function, or we're processing data
+			elif (opcode_byte in unconditional_jumps + unconditional_returns) or is_data:
+				# define data if it is located at the current offset
+				if local_offset not in byte_labels.keys() and local_offset in data_tables.keys() and created_but_unused_labels_exist(data_tables) and parse_data:
+					is_data = True
+				#stop reading at a jump, relative jump or return
+				elif all_byte_labels_are_defined(byte_labels) and (offset >= stop_offset or stop_offset_undefined):
+					break
+				# otherwise, add some spacing
+				output += "\n"
+		
+		# before returning output, we need to clean up some things
+		
+		# first, clean up on unused byte labels
+		for label_line in byte_labels.values():
+			if label_line["usage"] == 0:
+				output = output.replace((label_line["name"] + "\n"), "")
+		
+		# clean up on unused data labels
+		# this is slightly trickier to do as arguments for two byte variables use data labels
+		
+		# create a list of the output lines including the newlines
+		output_lines = [e+"\n" for e in output.split("\n") if e != ""]
+		
+		# go through each label
+		for label_addr in data_tables.keys():
+			# get the label dict
+			label_line = data_tables[label_addr]
+			# check if this label is unused
+			if label_line["usage"] == 0:
+				# get label name
+				label_name = label_line["name"]
+				# loop over all output lines
+				for i, line in enumerate(output_lines):
+					if line.startswith(label_name):
+					# remove line if it starts with the current label
+						output_lines.pop(i)
+					elif label_name in line:
+					# if the label is used in a load-based opcode, replace it with the raw hex reference
+						output_lines[i] = output_lines[i].replace(label_name, "$%x" % get_local_address(label_addr))
+		
+		# convert the modified list of lines into a string
+		output = "".join(output_lines)
+		
+		# tone down excessive spacing
+		output = output.replace("\n\n\n","\n\n")
 
-        #we don't actually have an end address, but we'll just say $4000
-        end_address = original_offset + max_byte_count
+		# add the offset of the final location
+		if include_last_address:
+			output += "; " + hex(offset)
+		
+		return [output, offset, stop_offset, byte_labels, data_labels]
 
-        byte_labels = {}
-        data_tables = {}
-
-        first_loop = True
-        output = ""
-        keep_reading = True
-        is_data = False
-        while offset <= end_address and keep_reading:
-            current_byte = rom[offset]
-            maybe_byte = current_byte
-
-            # stop at any address
-            if not first_loop and offset in stop_at:
-                keep_reading = False
-                break
-
-            #first check if this byte already has a label
-            #if it does, use the label
-            #if not, generate a new label
-            if offset in byte_labels.keys():
-                line_label = byte_labels[offset]["name"]
-                byte_labels[offset]["usage"] += 1
-                output += "\n"
-            else:
-                line_label = asm_label(offset)
-                byte_labels[offset] = {}
-                byte_labels[offset]["name"] = line_label
-                byte_labels[offset]["usage"] = 0
-            byte_labels[offset]["definition"] = True
-            output += line_label + "\n" #" ; " + hex(offset) + "\n"
-
-            #find out if there's a two byte key like this
-            temp_maybe = maybe_byte
-            temp_maybe += ( rom[offset+1] << 8)
-            if not is_data and temp_maybe in opt_table.keys() and rom[offset+1]!=0:
-                opstr = opt_table[temp_maybe][0].lower()
-
-                if "x" in opstr:
-                    for x in range(0, opstr.count("x")):
-                        insertion = rom[offset + 1]
-                        insertion = "$" + hex(insertion)[2:]
-
-                        opstr = opstr[:opstr.find("x")].lower() + insertion + opstr[opstr.find("x")+1:].lower()
-
-                        current_byte += 1
-                        offset += 1
-                if "?" in opstr:
-                    for y in range(0, opstr.count("?")):
-                        byte1 = rom[offset + 1]
-                        byte2 = rom[offset + 2]
-
-                        number = byte1
-                        number += byte2 << 8;
-
-                        insertion = "$%.4x" % (number)
-
-                        opstr = opstr[:opstr.find("?")].lower() + insertion + opstr[opstr.find("?")+1:].lower()
-
-                        current_byte_number += 2
-                        offset += 2
-
-                output += self.spacing + opstr #+ " ; " + hex(offset)
-                output += "\n"
-
-                current_byte_number += 2
-                offset += 2
-            elif not is_data and maybe_byte in opt_table.keys():
-                op_code = opt_table[maybe_byte]
-                op_code_type = op_code[1]
-                op_code_byte = maybe_byte
-
-                #type = -1 when it's the E op
-                #if op_code_type != -1:
-                if   op_code_type == 0 and rom[offset] == op_code_byte:
-                    op_str = op_code[0].lower()
-
-                    output += self.spacing + op_code[0].lower() #+ " ; " + hex(offset)
-                    output += "\n"
-
-                    offset += 1
-                    current_byte_number += 1
-                elif op_code_type == 1 and rom[offset] == op_code_byte:
-                    oplen = len(op_code[0])
-                    opstr = copy(op_code[0])
-                    xes = op_code[0].count("x")
-                    include_comment = False
-                    for x in range(0, xes):
-                        insertion = rom[offset + 1]
-                        insertion = "$" + hex(insertion)[2:]
-
-                        if current_byte == 0x18 or current_byte==0x20 or current_byte in relative_jumps: #jr or jr nz
-                            #generate a label for the byte we're jumping to
-                            target_address = offset + 2 + c_int8(rom[offset + 1]).value
-                            if target_address in byte_labels.keys():
-                                byte_labels[target_address]["usage"] = 1 + byte_labels[target_address]["usage"]
-                                line_label2 = byte_labels[target_address]["name"]
-                            else:
-                                line_label2 = asm_label(target_address)
-                                byte_labels[target_address] = {}
-                                byte_labels[target_address]["name"] = line_label2
-                                byte_labels[target_address]["usage"] = 1
-                                byte_labels[target_address]["definition"] = False
-
-                            insertion = line_label2
-                            if has_outstanding_labels(byte_labels) and all_outstanding_labels_are_reverse(byte_labels, offset):
-                                include_comment = True
-                        elif current_byte == 0x3e:
-                            last_a_address = rom[offset + 1]
-
-                        opstr = opstr[:opstr.find("x")].lower() + insertion + opstr[opstr.find("x")+1:].lower()
-
-                        # because the $ff00+$ff syntax is silly
-                        if opstr.count("$") > 1 and "+" in opstr:
-                            first_orig = opstr[opstr.find("$"):opstr.find("+")]
-                            first_val = eval(first_orig.replace("$","0x"))
-
-                            second_orig = opstr[opstr.find("+$")+1:opstr.find("]")]
-                            second_val = eval(second_orig.replace("$","0x"))
-
-                            combined_val = "$%.4x" % (first_val + second_val)
-                            result = self.find_label(combined_val, bank_id)
-                            if result != None:
-                                combined_val = result
-
-                            replacetron = "[%s+%s]" % (first_orig, second_orig)
-                            opstr = opstr.replace(replacetron, "[%s]" % combined_val)
-
-                        output += self.spacing + opstr
-                        if include_comment:
-                            output += " ; " + hex(offset)
-                            if current_byte in relative_jumps:
-                                output += " $" + hex(rom[offset + 1])[2:]
-                        output += "\n"
-
-                        current_byte_number += 1
-                        offset += 1
-                        insertion = ""
-
-                    current_byte_number += 1
-                    offset += 1
-                    include_comment = False
-                elif op_code_type == 2 and rom[offset] == op_code_byte:
-                    oplen = len(op_code[0])
-                    opstr = copy(op_code[0])
-                    qes = op_code[0].count("?")
-                    for x in range(0, qes):
-                        byte1 = rom[offset + 1]
-                        byte2 = rom[offset + 2]
-
-                        number = byte1
-                        number += byte2 << 8
-
-                        if current_byte not in call_commands + discrete_jumps + relative_jumps:
-                            pointer = get_global_address(number, bank_id)
-                            if pointer not in data_tables.keys():
-                                data_tables[pointer] = {}
-                                data_tables[pointer]['usage'] = 0
-                            else:
-                                data_tables[pointer]['usage'] += 1
-
-                        insertion = "$%.4x" % (number)
-                        result = self.find_label(insertion, bank_id)
-                        if result != None:
-                            insertion = result
-
-                        opstr = opstr[:opstr.find("?")].lower() + insertion + opstr[opstr.find("?")+1:].lower()
-                        output += self.spacing + opstr #+ " ; " + hex(offset)
-                        output += "\n"
-
-                        current_byte_number += 2
-                        offset += 2
-
-                    current_byte_number += 1
-                    offset += 1
-
-                    if current_byte == 0x21:
-                        last_hl_address = byte1 + (byte2 << 8)
-                    if current_byte == 0xcd:
-                        if number == 0x3d97: used_3d97 = True
-
-                    #duck out if this is jp $24d7
-                    if current_byte == 0xc3 or current_byte in relative_unconditional_jumps:
-                        if current_byte == 0xc3:
-                            if number == 0x3d97: used_3d97 = True
-                        #if number == 0x24d7: #jp
-                        if not has_outstanding_labels(byte_labels) or all_outstanding_labels_are_reverse(byte_labels, offset):
-                            keep_reading = False
-                            is_data = False
-                            break
-                else:
-                    is_data = True
-            else:
-            #if is_data and keep_reading:
-                output += self.spacing + "db $" + hex(rom[offset])[2:] #+ " ; " + hex(offset)
-                output += "\n"
-                offset += 1
-                current_byte_number += 1
-                if offset in byte_labels.keys():
-                    is_data = False
-                    keep_reading = True
-            #else the while loop would have spit out the opcode
-
-            #these two are done prior
-            #offset += 1
-            #current_byte_number += 1
-
-            if not is_data and current_byte in relative_unconditional_jumps + end_08_scripts_with:
-                #stop reading at a jump, relative jump or return
-                if not has_outstanding_labels(byte_labels) or all_outstanding_labels_are_reverse(byte_labels, offset):
-                    keep_reading = False
-                    is_data = False #cleanup
-                    break
-                elif offset not in byte_labels.keys() and offset in data_tables.keys():
-                    is_data = True
-                    keep_reading = True
-                else:
-                    is_data = False
-                    keep_reading = True
-                output += "\n"
-            elif is_data and offset not in byte_labels.keys():
-                is_data = True
-                keep_reading = True
-            else:
-                is_data = False
-                keep_reading = True
-
-            if offset in data_tables.keys():
-                output = output.replace('$%x' % (get_local_address(offset)), data_label(offset))
-                output += data_label(offset) + '\n'
-                is_data = True
-                keep_reading = True
-
-            first_loop = False
-
-        #clean up unused labels
-        for label_line in byte_labels.keys():
-            address = label_line
-            label_line = byte_labels[label_line]
-            if label_line["usage"] == 0:
-                output = output.replace((label_line["name"] + "\n"), "")
-
-        #tone down excessive spacing
-        output = output.replace("\n\n\n","\n\n")
-
-        #add the offset of the final location
-        if include_last_address:
-            output += "; " + hex(offset)
-
-        return (output, offset, last_hl_address, last_a_address, used_3d97)
+def get_raw_addr(addr):
+	if addr:
+		if ":" in addr:
+			addr = addr.split(":")
+			addr = int(addr[0], 16)*0x4000+(int(addr[1], 16)%0x4000)
+		else:
+			label_addr = disasm.find_address_from_label(addr)
+			if label_addr:
+				addr = label_addr
+			else:
+				addr = int(addr, 16)
+	
+	return addr
 
 if __name__ == "__main__":
-    conf = configuration.Config()
-    disasm = Disassembler(conf)
-    disasm.initialize()
-
-    addr = sys.argv[1]
-    if ":" in addr:
-        addr = addr.split(":")
-        addr = int(addr[0], 16)*0x4000+(int(addr[1], 16)%0x4000)
-    else:
-        label_addr = disasm.find_address_from_label(addr)
-        if label_addr:
-            addr = label_addr
-        else:
-            addr = int(addr, 16)
-
-    output = disasm.output_bank_opcodes(addr)[0]
-    print output
+	# argument parser
+	ap = argparse.ArgumentParser()
+	ap.add_argument("-r", dest="rom", default="baserom.gbc")
+	ap.add_argument("-o", dest="filename", default="gbz80disasm_output.asm")
+	ap.add_argument("-s", dest="symfile")
+	ap.add_argument("-dp", "--use-disasm-path", dest="use_disasm_path", action="store_true")
+	ap.add_argument("-q", "--quiet", dest="quiet", action="store_true")
+	ap.add_argument("-nw", "--no-write", dest="no_write", action="store_true")
+	ap.add_argument("-d", "--dry-run", dest="dry_run", action="store_true")
+	ap.add_argument("-pd", "--parse_data", dest="parse_data", action="store_true")
+	ap.add_argument('offset')
+	ap.add_argument('end', nargs='?')
+	
+	args = ap.parse_args()
+	# if symfile is unspecified, use the rom name as the symfile name
+	if args.symfile is None:
+		args.symfile = args.rom.split(".")[0] + ".sym"
+	
+	# flag to determine whether to use the extras submodule path for labels/constants or the disassembly path
+	if args.use_disasm_path:
+		conf = configuration.Config(path=os.path.abspath(os.path.join(os.getcwd(),"../..")))
+	else:
+		conf = configuration.Config()
+	
+	# initialize disassembler
+	disasm = Disassembler(conf)
+	disasm.initialize(args.rom, args.symfile)
+	
+	# get global address of the start and stop offsets
+	start_addr = get_raw_addr(args.offset)
+	stop_addr = get_raw_addr(args.end)
+	
+	# run the disassembler and return the output
+	output = disasm.output_bank_opcodes(start_addr,stop_addr,hard_stop=args.dry_run,parse_data=args.parse_data)[0]
+	
+	# suppress output if quiet flag is set
+	if not args.quiet:
+		print output
+	
+	# only write to the output file if the no write flag is unset
+	if not args.no_write:
+		with open(args.filename, "w") as f:
+			f.write(output)

--- a/pokemontools/gbz80disasm.py
+++ b/pokemontools/gbz80disasm.py
@@ -2,13 +2,15 @@
 """
 GBC disassembler
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import argparse
 from ctypes import c_int8
 
-import configuration
-from wram import read_constants
+from . import configuration
+from .wram import read_constants
 
 z80_table = [
 	('nop', 0),                    # 00
@@ -392,20 +394,20 @@ def load_symbols(path):
 		label = symbol['label']
 		
 		if 0x0000 <= address < 0x8000:
-			if not sym.has_key(bank):
+			if bank not in sym:
 				sym[bank] = {}
 			
 			sym[bank][address] = label
 			reverse_sym[label] = get_global_address(address, bank)
 			
 		elif 0xa000 <= address < 0xc000:
-			if not sram_sym.has_key(bank):
+			if bank not in sram_sym:
 				sram_sym[bank] = {}
 				
 			sram_sym[bank][address] = label
 			
 		elif address < 0xe000:
-			if not wram_sym.has_key(bank):
+			if bank not in wram_sym:
 				wram_sym[bank] = {}
 			
 			wram_sym[bank][address] = label
@@ -575,7 +577,7 @@ class Disassembler(object):
 			stop_offset = (bank_id + 1) * 0x4000 - 1
 	
 		if debug:
-			print "bank id is: " + str(bank_id)
+			print("bank id is: " + str(bank_id))
 
 		rom = self.rom
 
@@ -904,7 +906,7 @@ if __name__ == "__main__":
 	
 	# suppress output if quiet flag is set
 	if not args.quiet:
-		print output
+		print(output)
 	
 	# only write to the output file if the no write flag is unset
 	if not args.no_write:

--- a/pokemontools/gfx.py
+++ b/pokemontools/gfx.py
@@ -1,16 +1,18 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 import sys
-import png
+from . import png
 from math import sqrt, floor, ceil
 import argparse
 import operator
 
-import configuration
+from . import configuration
 config = configuration.Config()
 
-from lz import Compressed, Decompressed
+from .lz import Compressed, Decompressed
 
 
 def split(list_, interval):
@@ -69,7 +71,7 @@ def transpose(tiles, width=None):
     """
     if width == None:
         width = int(sqrt(len(tiles))) # assume square image
-    tiles = sorted(enumerate(tiles), key= lambda (i, tile): i % width)
+    tiles = sorted(enumerate(tiles), key= lambda i_tile: i_tile[0] % width)
     return [tile for i, tile in tiles]
 
 def transpose_tiles(image, width=None):
@@ -290,7 +292,7 @@ def dmg2rgb(word):
             value >>= 5
     word = shift(word)
     # distribution is less even w/ << 3
-    red, green, blue = [int(color * 8.25) for color in [word.next() for _ in xrange(3)]]
+    red, green, blue = [int(color * 8.25) for color in [next(word) for _ in xrange(3)]]
     alpha = 255
     return (red, green, blue, alpha)
 
@@ -487,9 +489,9 @@ def convert_2bpp_to_png(image, **kwargs):
                 matches += [(w, h)]
         # go for the most square image
         if len(matches):
-            width, height = sorted(matches, key= lambda (w, h): (h % 8 != 0, w + h))[0] # favor height
+            width, height = sorted(matches, key= lambda w_h: (w_h[1] % 8 != 0, w_h[0] + w_h[1]))[0] # favor height
         else:
-            raise Exception, 'Image can\'t be divided into tiles (%d px)!' % (px_length(image))
+            raise Exception('Image can\'t be divided into tiles (%d px)!' % (px_length(image)))
 
     # convert tiles to lines
     lines = to_lines(flatten(image), width)
@@ -530,7 +532,7 @@ def get_pic_animation(tmap, w, h):
         which_bitmask = bitmasks.index(bitmask)
 
         mask = iter(bitmask)
-        masked_frame = filter(lambda _: mask.next(), frame)
+        masked_frame = filter(lambda _: next(mask), frame)
 
         frame_text += '.frame{}\n'.format(i + 1)
         frame_text += '\tdb ${:02x} ; bitmask\n'.format(which_bitmask)
@@ -653,9 +655,9 @@ def png_to_2bpp(filein, **kwargs):
                     palette += [color]
                 else:
                     # TODO Find the nearest match
-                    print 'WARNING: %s: Color %s truncated to' % (filein, color),
+                    print('WARNING: %s: Color %s truncated to' % (filein, color), end=' ')
                     color = sorted(palette, key=lambda x: sum(x.values()))[0]
-                    print color
+                    print(color)
             newline += [color]
         image += [newline]
 
@@ -865,7 +867,7 @@ def convert_to_2bpp(filenames=[]):
         elif extension == '.png':
             export_png_to_2bpp(filename)
         else:
-            raise Exception, "Don't know how to convert {} to 2bpp!".format(filename)
+            raise Exception("Don't know how to convert {} to 2bpp!".format(filename))
 
 def convert_to_1bpp(filenames=[]):
     for filename in filenames:
@@ -877,7 +879,7 @@ def convert_to_1bpp(filenames=[]):
         elif extension == '.png':
             export_png_to_1bpp(filename)
         else:
-            raise Exception, "Don't know how to convert {} to 1bpp!".format(filename)
+            raise Exception("Don't know how to convert {} to 1bpp!".format(filename))
 
 def convert_to_png(filenames=[]):
     for filename in filenames:
@@ -889,7 +891,7 @@ def convert_to_png(filenames=[]):
         elif extension == '.png':
             pass
         else:
-            raise Exception, "Don't know how to convert {} to png!".format(filename)
+            raise Exception("Don't know how to convert {} to png!".format(filename))
 
 def compress(filenames=[]):
     for filename in filenames:
@@ -933,7 +935,7 @@ def main():
     }.get(args.mode, None)
 
     if method == None:
-        raise Exception, "Unknown conversion method!"
+        raise Exception("Unknown conversion method!")
 
     method(args.filenames)
 

--- a/pokemontools/gfx.py
+++ b/pokemontools/gfx.py
@@ -19,7 +19,7 @@ def split(list_, interval):
     """
     Split a list by length.
     """
-    for i in xrange(0, len(list_), interval):
+    for i in range(0, len(list_), interval):
         j = min(i + interval, len(list_))
         yield list_[i:j]
 
@@ -249,7 +249,7 @@ def flatten(planar):
         bottom = bottom
         top = top
         strip = []
-        for i in xrange(7,-1,-1):
+        for i in range(7,-1,-1):
             color = (
                 (bottom >> i & 1) +
                 (top *2 >> i & 2)
@@ -268,10 +268,10 @@ def to_lines(image, width):
     height = len(image) / width
 
     lines = []
-    for cur_line in xrange(height):
+    for cur_line in range(height):
         tile_row = cur_line / tile_height
         line = []
-        for column in xrange(num_columns):
+        for column in range(num_columns):
             anchor = (
                 num_columns * tile_row * tile_width * tile_height +
                 column * tile_width * tile_height +
@@ -292,7 +292,7 @@ def dmg2rgb(word):
             value >>= 5
     word = shift(word)
     # distribution is less even w/ << 3
-    red, green, blue = [int(color * 8.25) for color in [next(word) for _ in xrange(3)]]
+    red, green, blue = [int(color * 8.25) for color in [next(word) for _ in range(3)]]
     alpha = 255
     return (red, green, blue, alpha)
 
@@ -448,7 +448,7 @@ def convert_2bpp_to_png(image, **kwargs):
         trailing = len(image) % pic_length
 
         pic = []
-        for i in xrange(0, len(image) - trailing, pic_length):
+        for i in range(0, len(image) - trailing, pic_length):
             pic += transpose_tiles(image[i:i+pic_length], h)
         image = bytearray(pic) + image[len(image) - trailing:]
 
@@ -522,7 +522,7 @@ def get_pic_animation(tmap, w, h):
     base = frames.pop(0)
     bitmasks = []
 
-    for i in xrange(len(frames)):
+    for i in range(len(frames)):
         frame_text += '\tdw .frame{}\n'.format(i + 1)
 
     for i, frame in enumerate(frames):
@@ -648,7 +648,7 @@ def png_to_2bpp(filein, **kwargs):
     palette = []
     for line in rgba:
         newline = []
-        for px in xrange(0, len(line), len_px):
+        for px in range(0, len(line), len_px):
             color = dict(zip('rgba', line[px:px+len_px]))
             if color not in palette:
                 if len(palette) < 4:
@@ -704,11 +704,11 @@ def png_to_2bpp(filein, **kwargs):
     num_rows = max(height, tile_height) / tile_height
     image = []
 
-    for row in xrange(num_rows):
-        for column in xrange(num_columns):
+    for row in range(num_rows):
+        for column in range(num_columns):
 
             # Split it up into strips to convert to planar data
-            for strip in xrange(min(tile_height, height)):
+            for strip in range(min(tile_height, height)):
                 anchor = (
                     row * num_columns * tile_width * tile_height +
                     column * tile_width +
@@ -737,10 +737,10 @@ def png_to_2bpp(filein, **kwargs):
         tile_width = width / 8
         trailing = len(tiles) % pic_length
         new_image = []
-        for block in xrange(len(tiles) / pic_length):
+        for block in range(len(tiles) / pic_length):
             offset = (h * tile_width) * ((block * w) / tile_width) + ((block * w) % tile_width)
             pic = []
-            for row in xrange(h):
+            for row in range(h):
                 index = offset + (row * tile_width)
                 pic += tiles[index:index + w]
             new_image += transpose(pic, w)

--- a/pokemontools/graph.py
+++ b/pokemontools/graph.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+from __future__ import absolute_import
 import networkx as nx
 
-from romstr import (
+from .romstr import (
     RomStr,
     relative_jumps,
     call_commands,
@@ -92,7 +94,7 @@ class RomGraph(nx.DiGraph):
             # check if there are any nops (probably not a function)
             nops = 0
             for (id, command) in func.asm_commands.items():
-                if command.has_key("id") and command["id"] == 0x0:
+                if "id" in command and command["id"] == 0x0:
                     nops += 1
 
                     # skip this function
@@ -131,7 +133,7 @@ class RomGraph(nx.DiGraph):
         Shows some text output describing which nodes point to which other
         nodes.
         """
-        print self.edges()
+        print(self.edges())
 
     def to_d3(self):
         """

--- a/pokemontools/interval_map.py
+++ b/pokemontools/interval_map.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from bisect import bisect_left, bisect_right
-from itertools import izip
+try:
+    from future_builtins import zip
+except ImportError:
+    pass
+
 
 class IntervalMap(object):
     """
@@ -75,7 +79,7 @@ class IntervalMap(object):
         ((low_bound, high_bound), value)
         these items are returned in order"""
         previous_bound = None
-        for (b, v) in izip(self._bounds, self._items):
+        for (b, v) in zip(self._bounds, self._items):
             if v is not None:
                 yield (previous_bound, b), v
             previous_bound = b

--- a/pokemontools/labels.py
+++ b/pokemontools/labels.py
@@ -2,13 +2,14 @@
 """
 Various label/line-related functions.
 """
+from __future__ import absolute_import
 
 import os
 import json
 import logging
 
-import pointers
-import sym
+from . import pointers
+from . import sym
 
 class Labels(object):
     """
@@ -31,7 +32,7 @@ class Labels(object):
         if not os.path.exists(self.path):
             self.filename = find_symfile_in_dir(self.config.path)
             if self.filename == None:
-                raise Exception, "Couldn't find any .sym files. Run rgblink -n to create a .sym file."
+                raise Exception("Couldn't find any .sym files. Run rgblink -n to create a .sym file.")
             self.path = os.path.join(self.config.path, self.filename)
 
         self.labels = sym.read_symfile(self.path)
@@ -178,7 +179,7 @@ def get_address_from_line_comment(line, bank=None):
 def line_has_label(line):
     """returns True if the line has an asm label"""
     if not isinstance(line, str):
-        raise Exception, "can't check this type of object"
+        raise Exception("can't check this type of object")
     line = line.rstrip(" ").lstrip(" ")
     line = remove_quoted_text(line)
     if ";" in line:

--- a/pokemontools/labels.py
+++ b/pokemontools/labels.py
@@ -192,6 +192,8 @@ def line_has_label(line):
         return False
     if line[0] == "\"":
         return False
+    if line[0] == ":":
+        return False
     return True
 
 def get_label_from_line(line):

--- a/pokemontools/lz.py
+++ b/pokemontools/lz.py
@@ -2,6 +2,7 @@
 """
 Pokemon Crystal data de/compression.
 """
+from __future__ import print_function
 
 """
 A rundown of Pokemon Crystal's compression scheme:
@@ -9,7 +10,6 @@ A rundown of Pokemon Crystal's compression scheme:
 Control commands occupy bits 5-7.
 Bits 0-4 serve as the first parameter <n> for each command.
 """
-from __future__ import print_function
 lz_commands = {
     'literal':   0, # n values for n bytes
     'iterate':   1, # one value for n bytes
@@ -45,8 +45,8 @@ lz_end = 0xff
 
 
 bit_flipped = [
-    sum(((byte >> i) & 1) << (7 - i) for i in xrange(8))
-    for byte in xrange(0x100)
+    sum(((byte >> i) & 1) << (7 - i) for i in range(8))
+    for byte in range(0x100)
 ]
 
 
@@ -190,7 +190,7 @@ class Compressed:
         )
         for method in self.lookback_methods:
             min_score = self.min_scores[method]
-            for address in xrange(self.address+1, self.address+best_score):
+            for address in range(self.address+1, self.address+best_score):
                 length, index = self.find_lookback(method, address)
                 if length > max(min_score, best_score):
                     # BUG: lookbacks can reduce themselves. This appears to be a bug in the target also.
@@ -212,7 +212,7 @@ class Compressed:
 
     def find_lookback(self, method, address=None):
         """Temporarily stubbed, because the real function doesn't run in polynomial time."""
-	return 0, None
+        return 0, None
 
     def broken_find_lookback(self, method, address=None):
         if address is None:
@@ -544,7 +544,7 @@ class Decompressed:
         Write alternating bytes.
         """
         alts = [next(self), next(self)]
-        self.output += [ alts[x & 1] for x in xrange(self.length) ]
+        self.output += [ alts[x & 1] for x in range(self.length) ]
 
     def blank(self):
         """
@@ -576,6 +576,6 @@ class Decompressed:
         self.get_offset()
         self.direction = direction
         # Note: appends must be one at a time (this way, repeats can draw from themselves if required)
-        for i in xrange(self.length):
+        for i in range(self.length):
             byte = self.output[ self.offset + i * direction ]
             self.output.append( table[byte] if table else byte )

--- a/pokemontools/map_editor.py
+++ b/pokemontools/map_editor.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import sys
 import logging
@@ -36,10 +37,10 @@ from PIL import (
     ImageTk,
 )
 
-import gfx
-import wram
-import preprocessor
-import configuration
+from . import gfx
+from . import wram
+from . import preprocessor
+from . import configuration
 config = configuration.Config()
 
 

--- a/pokemontools/map_gfx.py
+++ b/pokemontools/map_gfx.py
@@ -1,9 +1,11 @@
 """
 Map-related graphic functions.
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
-import png
+from . import png
 from io import BytesIO
 
 from PIL import (
@@ -11,8 +13,8 @@ from PIL import (
     ImageDraw,
 )
 
-import crystal
-import gfx
+from . import crystal
+from . import gfx
 
 tile_width = 8
 tile_height = 8
@@ -285,7 +287,7 @@ def draw_map_sprites(map_header, map_image, config=config):
         other_args = {}
 
         if sprite_image_id not in sprites.keys() or sprite_image_id > 0x66:
-            print "sprite_image_id {} is not in sprites".format(sprite_image_id)
+            print("sprite_image_id {} is not in sprites".format(sprite_image_id))
 
             sprite_image = Image.new("RGBA", (16, 16))
 
@@ -362,7 +364,7 @@ def save_map(map_group_id, map_id, savedir, show_sprites=True, config=config):
 
     palettes = read_palettes(config=config)
 
-    print "Drawing {}".format(map_name)
+    print("Drawing {}".format(map_name))
     map_image = draw_map(map_group_id, map_id, palettes, show_sprites=show_sprites, config=config)
     map_image.save(filepath)
 

--- a/pokemontools/old_parse_scripts.py
+++ b/pokemontools/old_parse_scripts.py
@@ -5,21 +5,22 @@ do anything on its own.
 
 old_parse is a part of the Script class
 """
+from __future__ import print_function
 
 def old_parse(self, *args, **kwargs):
     """parses a script-engine script; force=True if you want to re-parse
     and get the debug information"""
-    print "Script.old_parse address="+hex(self.address)
+    print("Script.old_parse address="+hex(self.address))
     #can't handle more than one argument
     if len(args) > 1:
-        raise Exception, "Script.parse_script doesn't know how to handle positional arguments"
+        raise Exception("Script.parse_script doesn't know how to handle positional arguments")
     #use the first positional argument as the address
     elif len(args) == 1:
         self.address = args[0]
         if type(self.address) == str:
             self.address = int(self.address, 16)
         elif type(self.address) != int:
-            raise Exception, "address param is the wrong type"
+            raise Exception("address param is the wrong type")
     #parse any keyword arguments, first make up the defaults
     kwargsorig = {"map_group": None, "map_id": None, "force": False, "debug": True, "origin": False}
     #let the caller override any defaults
@@ -48,16 +49,16 @@ def old_parse(self, *args, **kwargs):
 
     #don't parse these crazy things (battle tower things, some rival things, etc.)
     if address in stop_points:
-        print "got " + hex(address) + ".. map_group=" + str(map_group) + " map_id=" + str(map_id)
+        print("got " + hex(address) + ".. map_group=" + str(map_group) + " map_id=" + str(map_id))
         return None
     #don't parse anything that looks crazy
     if address < 0x4000 and address not in [0x26ef, 0x114, 0x1108]:
-        print "address is less than 0x4000.. address is: " + hex(address)
+        print("address is less than 0x4000.. address is: " + hex(address))
         sys.exit()
 
     #check if work is being repeated
     if is_script_already_parsed_at(address) and not force:
-        raise Exception, "this script has already been parsed before, please use that instance"
+        raise Exception("this script has already been parsed before, please use that instance")
         #use the commands from a previously-parsed Script object
         #self.commands = script_parse_table[address].commands
         #return True
@@ -90,8 +91,8 @@ def old_parse(self, *args, **kwargs):
         start_address = offset
 
         if (len(commands.keys()) > max_cmds) and origin != False:
-            print "too many commands in this script? might not be a script (starting at: " +\
-                  hex(original_start_address) + ").. called from a script at: " + hex(origin)
+            print("too many commands in this script? might not be a script (starting at: " +\
+                  hex(original_start_address) + ").. called from a script at: " + hex(origin))
             sys.exit()
 
         #start checking against possible command bytes
@@ -107,12 +108,12 @@ def old_parse(self, *args, **kwargs):
             last_byte_address = offset + size - 1
             pointer = calculate_pointer_from_bytes_at(start_address+1)
             if pointer == None:
-                raise Exception, "pointer is None (shouldn't be None pointer on 0x0 script command"
+                raise Exception("pointer is None (shouldn't be None pointer on 0x0 script command")
             command["pointer"] = pointer
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                       " about to parse script at "+hex(pointer)+\
-                      " called by "+info+" byte="+hex(command_byte)
+                      " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug=debug)
             command["script"] = script
         elif command_byte == 0x01: #Pointer code [3b+ret]
@@ -126,9 +127,9 @@ def old_parse(self, *args, **kwargs):
             info = "pointer code"
             pointer = calculate_pointer_from_bytes_at(start_address+1, bank=True)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                       " about to parse script at "+hex(pointer)+\
-                      " called by "+info+" byte="+hex(command_byte)
+                      " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug)
             command["pointer"] = pointer
             command["script"] = script
@@ -141,9 +142,9 @@ def old_parse(self, *args, **kwargs):
             size = 3
             pointer = calculate_pointer_from_bytes_at(start_address+1)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                       " about to parse script at "+hex(pointer)+\
-                      " called by "+info+" byte="+hex(command_byte)
+                      " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug=debug)
             command["pointer"] = pointer
             command["script"] = script
@@ -157,9 +158,9 @@ def old_parse(self, *args, **kwargs):
             size = 3
             pointer = calculate_pointer_from_bytes_at(start_address+1)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                       " about to parse script at "+hex(pointer)+\
-                      " called by "+info+" byte="+hex(command_byte)
+                      " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug=debug)
             command["pointer"] = pointer
             command["script"] = script
@@ -173,9 +174,9 @@ def old_parse(self, *args, **kwargs):
             size = 4
             pointer = calculate_pointer_from_bytes_at(start_address+1, bank=True)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                   " about to parse script at "+hex(pointer)+\
-                  " called by "+info+" byte="+hex(command_byte)
+                  " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug=debug)
             command["pointer"] = pointer
             command["script"] = script
@@ -191,9 +192,9 @@ def old_parse(self, *args, **kwargs):
             command["target_pointer"] = calculate_pointer_from_bytes_at(command["pointer"], bank=True)
 
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                   " about to parse script at "+hex(command["target_pointer"])+\
-                  " called by "+info+" byte="+hex(command_byte)
+                  " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(command["target_pointer"], original_start_address, debug=debug)
             command["script"] = script
             end = True #according to pksv
@@ -207,9 +208,9 @@ def old_parse(self, *args, **kwargs):
             command["byte"] = ord(rom[start_address+1])
             pointer = calculate_pointer_from_bytes_at(start_address+2)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                   " about to parse script at "+hex(pointer)+\
-                  " called by "+info+" byte="+hex(command_byte)
+                  " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug=debug)
             command["pointer"] = pointer
             command["script"] = script
@@ -223,9 +224,9 @@ def old_parse(self, *args, **kwargs):
             command["byte"] = ord(rom[start_address+1])
             pointer = calculate_pointer_from_bytes_at(start_address+2)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                   " about to parse script at "+hex(pointer)+\
-                  " called by "+info+" byte="+hex(command_byte)
+                  " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug=debug)
             command["pointer"] = pointer
             command["script"] = script
@@ -238,9 +239,9 @@ def old_parse(self, *args, **kwargs):
             size = 3
             pointer = calculate_pointer_from_bytes_at(start_address+1)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                   " about to parse script at "+hex(pointer)+\
-                  " called by "+info+" byte="+hex(command_byte)
+                  " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug=debug)
             command["pointer"] = pointer
             command["script"] = script
@@ -253,9 +254,9 @@ def old_parse(self, *args, **kwargs):
             size = 3
             pointer = calculate_pointer_from_bytes_at(start_address+1)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                   " about to parse script at "+hex(pointer)+\
-                  " called by "+info+" byte="+hex(command_byte)
+                  " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug=debug)
             command["pointer"] = pointer
             command["script"] = script
@@ -269,9 +270,9 @@ def old_parse(self, *args, **kwargs):
             command["byte"] = ord(rom[start_address+1])
             pointer = calculate_pointer_from_bytes_at(start_address+2)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                   " about to parse script at "+hex(pointer)+\
-                  " called by "+info+" byte="+hex(command_byte)
+                  " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug=debug)
             command["pointer"] = pointer
             command["script"] = script
@@ -285,9 +286,9 @@ def old_parse(self, *args, **kwargs):
             command["byte"] = ord(rom[start_address+1])
             pointer = calculate_pointer_from_bytes_at(start_address+2)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                   " about to parse script at "+hex(pointer)+\
-                  " called by "+info+" byte="+hex(command_byte)
+                  " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(pointer, original_start_address, debug=debug)
             command["pointer"] = pointer
             command["script"] = script
@@ -1588,9 +1589,9 @@ def old_parse(self, *args, **kwargs):
             size = 3
             script_pointer = calculate_pointer_from_bytes_at(start_address+1, bank=False)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                   " about to parse script at "+hex(script_pointer)+\
-                  " called by "+info+" byte="+hex(command_byte)
+                  " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(script_pointer, original_start_address, debug=debug)
             command["script_pointer"] = script_pointer
             command["script"] = script
@@ -1612,9 +1613,9 @@ def old_parse(self, *args, **kwargs):
             size = 3
             script_pointer = calculate_pointer_from_bytes_at(start_address+1, bank=False)
             if debug:
-                print "in script starting at "+hex(original_start_address)+\
+                print("in script starting at "+hex(original_start_address)+\
                   " about to parse script at "+hex(script_pointer)+\
-                  " called by "+info+" byte="+hex(command_byte)
+                  " called by "+info+" byte="+hex(command_byte))
             script = rec_parse_script_engine_script_at(script_pointer, original_start_address, debug=debug)
             command["script_pointer"] = script_pointer
             command["script"] = script
@@ -1854,7 +1855,7 @@ def old_parse(self, *args, **kwargs):
             size = 1
             #end = True
             #raise NotImplementedError, "command byte is " + hex(command_byte) + " at " + hex(offset) + " on map " + str(map_group) + "." + str(map_id)
-            print "dunno what this command is: " + hex(command_byte)
+            print("dunno what this command is: " + hex(command_byte))
         long_info = clean_up_long_info(long_info)
 
         if command_byte in pksv_crystal.keys():
@@ -1867,7 +1868,7 @@ def old_parse(self, *args, **kwargs):
                 pksv_no_names[command_byte] = [address]
 
         if debug:
-            print command_debug_information(command_byte=command_byte, map_group=map_group, map_id=map_id, address=offset, info=info, long_info=long_info, pksv_name=pksv_name)
+            print(command_debug_information(command_byte=command_byte, map_group=map_group, map_id=map_id, address=offset, info=info, long_info=long_info, pksv_name=pksv_name))
 
         #store the size of the command
         command["size"] = size

--- a/pokemontools/old_text_script.py
+++ b/pokemontools/old_text_script.py
@@ -1,8 +1,9 @@
 """
 An old implementation of TextScript that may not be useful anymore.
 """
+from __future__ import absolute_import
 
-import pointers
+from . import pointers
 
 class OldTextScript:
     "a text is a sequence of commands different from a script-engine script"
@@ -43,7 +44,7 @@ class OldTextScript:
                     if signpost["func"] in [0, 1, 2, 3, 4]:
                         # dump this into script
                         script = signpost["script"]
-                    elif signpost["func"] in [05, 06]:
+                    elif signpost["func"] in [0o5, 0o6]:
                         script = signpost["script"]
                     else: continue
                     # skip signposts with no bytes

--- a/pokemontools/overworldripper.py
+++ b/pokemontools/overworldripper.py
@@ -1,4 +1,5 @@
-import gfx
+from __future__ import absolute_import
+from . import gfx
 
 def rip_sprites_from_bank(bank, offset=0):
     """

--- a/pokemontools/parse_consecutive_strings.py
+++ b/pokemontools/parse_consecutive_strings.py
@@ -1,6 +1,8 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import sys
 
-import crystal
+from . import crystal
 
 rom = crystal.load_rom()
 
@@ -16,10 +18,10 @@ for i in range(count):
         asm = string.to_asm()
     except Exception as ex:
         break
-    print label_prefix+str(i)+": ; "+hex(addr)
-    print "\t"+asm
-    print
+    print(label_prefix+str(i)+": ; "+hex(addr))
+    print("\t"+asm)
+    print()
     addr = string.last_address
 
-print "; "+hex(addr)
+print("; "+hex(addr))
 if ex: raise ex

--- a/pokemontools/pcm.py
+++ b/pokemontools/pcm.py
@@ -110,7 +110,7 @@ def get_wav_samples(filename):
             fmt = 'h'
         else:
             # todo: support 3-byte sample width
-            raise Exception, "Unsupported sample width: " + str(sample_width)
+            raise Exception("Unsupported sample width: " + str(sample_width))
 
         value = struct.unpack(fmt, samples[i:i + sample_width])[0]
         unpacked_samples.append(value)
@@ -148,7 +148,7 @@ def main():
     }.get(args.mode, None)
 
     if method == None:
-        raise Exception, "Unknown conversion method!"
+        raise Exception("Unknown conversion method!")
 
     method(args.filenames)
 

--- a/pokemontools/pcm.py
+++ b/pokemontools/pcm.py
@@ -1,5 +1,8 @@
 # pcm.py
 # Converts between .wav files and 1-bit pcm data. (pcm = pulse-code modulation)
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import argparse
 import os
@@ -72,7 +75,7 @@ def convert_to_pcm(filenames=[]):
 
         # Pack the 1-bit samples together.
         packed_samples = bytearray()
-        for i in xrange(0, len(clamped_samples), 8):
+        for i in range(0, len(clamped_samples), 8):
             # Read 8 pcm values to pack one byte.
             packed_value = 0
             for j in range(8):
@@ -103,7 +106,7 @@ def get_wav_samples(filename):
 
     # Unpack the values based on the sample byte width.
     unpacked_samples = []
-    for i in xrange(0, len(samples), sample_width):
+    for i in range(0, len(samples), sample_width):
         if sample_width == 1:
             fmt = 'B'
         elif sample_width == 2:
@@ -122,7 +125,7 @@ def get_wav_samples(filename):
     # Also find the average amplitude of the samples.
     resampled_samples = []
     total_value = 0
-    interval = float(sample_rate) / BASE_SAMPLE_RATE
+    interval = sample_rate / BASE_SAMPLE_RATE
     index = 0
     while index < sample_count:
         sample = unpacked_samples[int(index)]
@@ -131,7 +134,7 @@ def get_wav_samples(filename):
         resampled_samples.append(sample)
         index += interval
 
-    average_sample = float(total_value) / len(resampled_samples)
+    average_sample = total_value / len(resampled_samples)
 
     return resampled_samples, average_sample
 

--- a/pokemontools/pic.py
+++ b/pokemontools/pic.py
@@ -4,6 +4,7 @@
 A library for use with compressed monster and trainer pics in pokered.
 """
 from __future__ import absolute_import
+from __future__ import division
 
 import os
 import sys
@@ -29,14 +30,14 @@ class Decompressor:
     Ported to python 2.7 from the python 3 code at https://github.com/magical/pokemon-sprites-rby.
     """
 
-    table1 = [(2 << i) - 1 for i in xrange(16)]
+    table1 = [(2 << i) - 1 for i in range(16)]
     table2 = [
         [0x0, 0x1, 0x3, 0x2, 0x7, 0x6, 0x4, 0x5, 0xf, 0xe, 0xc, 0xd, 0x8, 0x9, 0xb, 0xa],
         [0xf, 0xe, 0xc, 0xd, 0x8, 0x9, 0xb, 0xa, 0x0, 0x1, 0x3, 0x2, 0x7, 0x6, 0x4, 0x5], # prev ^ 0xf
         [0x0, 0x8, 0xc, 0x4, 0xe, 0x6, 0x2, 0xa, 0xf, 0x7, 0x3, 0xb, 0x1, 0x9, 0xd, 0x5],
         [0xf, 0x7, 0x3, 0xb, 0x1, 0x9, 0xd, 0x5, 0x0, 0x8, 0xc, 0x4, 0xe, 0x6, 0x2, 0xa], # prev ^ 0xf
     ]
-    table3 = [bitflip(i, 4) for i in xrange(16)]
+    table3 = [bitflip(i, 4) for i in range(16)]
 
     tilesize = 8
 
@@ -118,7 +119,7 @@ class Decompressor:
         a = self._readint(i + 1)
         n += a
 
-        for i in xrange(n):
+        for i in range(n):
             ram.append(0)
 
     def _read_data_chunk(self, ram, size):
@@ -135,9 +136,9 @@ class Decompressor:
         if mirror is None:
             mirror = self.mirror
 
-        for x in xrange(self.sizex):
+        for x in range(self.sizex):
             bit = 0
-            for y in xrange(self.sizey):
+            for y in range(self.sizey):
                 i = y * self.sizex + x
                 a = (ram[i] >> 4) & 0xf
                 b = ram[i] & 0xf
@@ -158,7 +159,7 @@ class Decompressor:
         if mirror is None:
             mirror = self.mirror
 
-        for i in xrange(len(ram2)):
+        for i in range(len(ram2)):
             if mirror:
                 a = (ram2[i] >> 4) & 0xf
                 b = ram2[i] & 0xf
@@ -170,10 +171,10 @@ class Decompressor:
 
     def _deinterlace_bitgroups(self, bits):
         l = []
-        for y in xrange(self.sizey):
-            for x in xrange(self.sizex):
+        for y in range(self.sizey):
+            for x in range(self.sizex):
                 i = 4 * y * self.sizex + x
-                for j in xrange(4):
+                for j in range(4):
                     l.append(bits[i])
                     i += self.sizex
         return l
@@ -193,12 +194,12 @@ def fbitstream(f):
             break
         byte = ord(char)
 
-        for i in xrange(7, -1, -1):
+        for i in range(7, -1, -1):
             yield (byte >> i) & 1
 
 def bitstream(b):
     for byte in b:
-        for i in xrange(7, -1, -1):
+        for i in range(7, -1, -1):
             yield (byte >> i) & 1
 
 def readint(bs, count):
@@ -211,7 +212,7 @@ def readint(bs, count):
 
 def bitgroups_to_bytes(bits):
     l = []
-    for i in xrange(0, len(bits) - 3, 4):
+    for i in range(0, len(bits) - 3, 4):
         n = ((bits[i + 0] << 6)
            | (bits[i + 1] << 4)
            | (bits[i + 2] << 2)
@@ -231,21 +232,21 @@ class Compressor:
     Adapted from stag019's C compressor.
     """
 
-    table1 = [(2 << i) - 1 for i in xrange(16)]
+    table1 = [(2 << i) - 1 for i in range(16)]
     table2 = [
         [0x0, 0x1, 0x3, 0x2, 0x6, 0x7, 0x5, 0x4, 0xc, 0xd, 0xf, 0xe, 0xa, 0xb, 0x9, 0x8],
         [0x8, 0x9, 0xb, 0xa, 0xe, 0xf, 0xd, 0xc, 0x4, 0x5, 0x7, 0x6, 0x2, 0x3, 0x1, 0x0], # reverse
     ]
-    table3 = [bitflip(i, 4) for i in xrange(16)]
+    table3 = [bitflip(i, 4) for i in range(16)]
 
     def __init__(self, image, width=None, height=None):
         self.image = bytearray(image)
         self.size = len(self.image)
 
-        planar_tile = 8 * 8 / 4
-        tile_size = self.size / planar_tile
-        if   height    and not width:  width  = tile_size / height
-        elif width     and not height: height = tile_size / width
+        planar_tile = 8 * 8 // 4
+        tile_size = self.size // planar_tile
+        if   height    and not width:  width  = tile_size // height
+        elif width     and not height: height = tile_size // width
         elif not width and not height: width = height = int(sqrt(tile_size))
         self.width, self.height = width, height
 
@@ -257,7 +258,7 @@ class Compressor:
         rams = [[],[]]
         datas = []
 
-        for mode in xrange(3):
+        for mode in range(3):
 
             # Order is redundant for mode 0.
 
@@ -270,10 +271,10 @@ class Compressor:
 
             # Using order 0 instead of 1 breaks this feature.
 
-            for order in xrange(2):
+            for order in range(2):
                 if mode == 0 and order == 0:
                     continue
-                for i in xrange(2):
+                for i in range(2):
                     rams[i] = self.image[i::2]
                 self._interpret_compress(rams, mode, order)
                 datas += [(self.data[:], int(self.which_bit))]
@@ -320,10 +321,10 @@ class Compressor:
         nums = 0
         bitgroups = []
 
-        for x in xrange(self.width):
-            for bit in xrange(0, 8, 2):
+        for x in range(self.width):
+            for bit in range(0, 8, 2):
                 byte = x * self.height * 8
-                for y in xrange(self.height * 8):
+                for y in range(self.height * 8):
                     bitgroup = (ram[byte] >> (6 - bit)) & 3
                     if bitgroup == 0:
                         if rle == 0:
@@ -378,16 +379,16 @@ class Compressor:
             v >>= 1
             bitcount += 1
 
-        for j in xrange(bitcount):
+        for j in range(bitcount):
             self._writebit(1)
         self._writebit(0)
-        for j in xrange(bitcount, -1, -1):
+        for j in range(bitcount, -1, -1):
             self._writebit((number >> j) & 1)
 
     def _encode(self, ram, mirror=None):
         a = b = 0
-        for i in xrange(len(ram)):
-            j = i / self.height
+        for i in range(len(ram)):
+            j = i // self.height
             j += i % self.height * self.width * 8
             if i % self.height == 0:
                 b = 0
@@ -403,7 +404,7 @@ class Compressor:
             ram[j] = (code_1 << 4) | code_2
 
     def _xor(self, ram1, ram2):
-        for i in xrange(len(ram2)):
+        for i in range(len(ram2)):
             ram2[i] ^= ram1[i]
 
     def _writebit(self, bit):
@@ -416,7 +417,7 @@ class Compressor:
     def _writeint(self, num, size=None):
         bits = []
         if size:
-            for i in xrange(size):
+            for i in range(size):
                 bits += [num & 1]
                 num >>= 1
         else:
@@ -469,7 +470,7 @@ def compress_file(filename):
     pic = bytearray(pic)
     output_filename = os.path.splitext(filename)[0] + '.pic'
     with open(output_filename, 'wb') as out:
-	out.write(pic)
+        out.write(pic)
 
 
 def main():

--- a/pokemontools/pic.py
+++ b/pokemontools/pic.py
@@ -3,13 +3,14 @@
 """
 A library for use with compressed monster and trainer pics in pokered.
 """
+from __future__ import absolute_import
 
 import os
 import sys
 import argparse
 from math import sqrt
 
-from gfx import transpose_tiles
+from .gfx import transpose_tiles
 
 
 def bitflip(x, n):
@@ -79,7 +80,7 @@ class Decompressor:
             self._decode(rams[r1])
             self._xor(rams[r1], rams[r2])
         else:
-            raise Exception, "Invalid deinterlace mode!"
+            raise Exception("Invalid deinterlace mode!")
 
         data = []
         if self.planar:
@@ -278,7 +279,7 @@ class Compressor:
                 datas += [(self.data[:], int(self.which_bit))]
 
         # Pick the smallest pic, measured in bits.
-        datas = sorted(datas, key=lambda (data, bit): (len(data), -bit))
+        datas = sorted(datas, key=lambda data_bit: (len(data_bit[0]), -data_bit[1]))
         self.data, self.which_bit = datas[0]
 
     def _interpret_compress(self, rams, mode, order):
@@ -299,7 +300,7 @@ class Compressor:
             self._encode(rams[r1])
             self._encode(rams[r2], mirror=False)
         else:
-            raise Exception, 'invalid interlace mode!'
+            raise Exception('invalid interlace mode!')
 
         self._writeint(self.height, 4)
         self._writeint(self.width,  4)

--- a/pokemontools/preprocessor.py
+++ b/pokemontools/preprocessor.py
@@ -2,12 +2,13 @@
 """
 Basic preprocessor for both pokecrystal and pokered.
 """
+from __future__ import absolute_import
 
 import os
 import sys
 
-import exceptions
-import crystal
+from . import exceptions
+from . import crystal
 
 chars = {
 "ガ": 0x05,

--- a/pokemontools/preprocessor.py
+++ b/pokemontools/preprocessor.py
@@ -566,11 +566,11 @@ class Preprocessor(object):
         if show_original_lines:
             sys.stdout.write("; original_line: " + original_line)
 
-	# rgbasm can handle other macros too
+        # rgbasm can handle other macros too
         if "is_rgbasm_macro" in dir(macro):
             if macro.is_rgbasm_macro:
                 sys.stdout.write(original_line)
-	        return
+                return
 
         # certain macros don't need an initial byte written
         # do: all scripting macros

--- a/pokemontools/redmusicdisasm.py
+++ b/pokemontools/redmusicdisasm.py
@@ -1,4 +1,5 @@
-import configuration
+from __future__ import absolute_import
+from . import configuration
 config = configuration.Config()
 rom = bytearray(open(config.rom_path, "r").read())
 

--- a/pokemontools/redsfxdisasm.py
+++ b/pokemontools/redsfxdisasm.py
@@ -1,4 +1,6 @@
-import configuration
+from __future__ import print_function
+from __future__ import absolute_import
+from . import configuration
 config = configuration.Config()
 rom = bytearray(open(config.rom_path, "r").read())
 
@@ -367,7 +369,7 @@ music_notes = {
 sfxnum = 0
 
 for bank in banks:
-	print bank
+	print(bank)
 	header = bank * 0x4000 + 3
 	for sfx in range(1,banks[bank]):
 		sfxname = sfx_names[sfxnum]

--- a/pokemontools/redsfxheaders.py
+++ b/pokemontools/redsfxheaders.py
@@ -1,4 +1,5 @@
-import configuration
+from __future__ import absolute_import
+from . import configuration
 config = configuration.Config()
 rom = bytearray(open(config.rom_path, "r").read())
 

--- a/pokemontools/romstr.py
+++ b/pokemontools/romstr.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+from __future__ import absolute_import
 import sys
 import os
 import time
@@ -12,7 +14,7 @@ import json
 if not hasattr(json, "read"):
     json.read = json.loads
 
-from labels import (
+from .labels import (
     get_label_from_line,
     get_address_from_line_comment,
 )
@@ -170,7 +172,7 @@ class RomStr(str):
         start_address = address
 
         if start_address == None:
-            raise Exception, "address must be given"
+            raise Exception("address must be given")
 
         if debug == None:
             if not hasattr(self, "debug"):
@@ -180,9 +182,9 @@ class RomStr(str):
 
         # this is probably a terrible idea.. why am i doing this?
         if size != None and max_size < size:
-            raise Exception, "max_size must be greater than or equal to size"
+            raise Exception("max_size must be greater than or equal to size")
         elif end_address != None and (end_address - start_address) > max_size:
-            raise Exception, "end_address is out of bounds"
+            raise Exception("end_address is out of bounds")
         elif end_address != None and size != None:
             if (end_address - start_address) >= size:
                 size = end_address - start_address
@@ -216,4 +218,4 @@ class AsmList(list):
 if __name__ == "__main__":
     cryrom = RomStr(open("../pokecrystal.gbc", "r").read());
     asm = cryrom.to_asm(sys.argv[1])
-    print asm
+    print(asm)

--- a/pokemontools/scan_includes.py
+++ b/pokemontools/scan_includes.py
@@ -4,40 +4,48 @@
 """
 Recursively scan an asm file for dependencies.
 """
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import sys
 import argparse
 import os.path
 
-includes = set()
 
 def scan_file(filename):
-	for line in open(filename):
-		if 'INC' not in line:
-			continue
-		line = line.split(';')[0]
-		if 'INCLUDE' in line:
-			include = line.split('"')[1]
-			if os.path.exists("src/"):
-				includes.add("src/" + include)
-				scan_file("src/" + include)
-			else:
-				includes.add(include)
-				scan_file(include)
-		elif 'INCBIN' in line:
-			include = line.split('"')[1]
-			if 'baserom.gbc' not in line and os.path.exists("src/"):
-				includes.add("src/" + include)
-			else:
-				includes.add(include)
+    with open(filename) as f:
+        for line in f:
+            if 'INC' not in line:
+                continue
+            line = line.split(';')[0]
+            if 'INCLUDE' in line:
+                include = line.split('"')[1]
+                if os.path.exists("src/"):
+                    yield "src/" + include
+                    for inc in scan_file("src/" + include):
+                        yield inc
+                else:
+                    yield include
+                    for inc in scan_file(include):
+                        yield inc
+            elif 'INCBIN' in line:
+                include = line.split('"')[1]
+                if 'baserom.gbc' not in line and os.path.exists("src/"):
+                    yield "src/" + include
+                else:
+                    yield include
+
 
 def main():
-	ap = argparse.ArgumentParser()
-	ap.add_argument('filenames', nargs='*')
-	args = ap.parse_args()
-	for filename in set(args.filenames):
-		scan_file(filename)
-	sys.stdout.write(' '.join(includes))
+    ap = argparse.ArgumentParser()
+    ap.add_argument('filenames', nargs='*')
+    args = ap.parse_args()
+    includes = set()
+    for filename in set(args.filenames):
+        includes.update(scan_file(filename))
+    sys.stdout.write(' '.join(sorted(includes)))
+
 
 if __name__ == '__main__':
-	main()
+    main()

--- a/pokemontools/tcgdisasm.py
+++ b/pokemontools/tcgdisasm.py
@@ -2,6 +2,8 @@
 """
 GBC disassembler, specialized for TCG macros
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
@@ -10,9 +12,9 @@ from ctypes import c_int8
 import random
 import json
 
-import configuration
-import labels
-import wram
+from . import configuration
+from . import labels
+from . import wram
 
 # New versions of json don't have read anymore.
 if not hasattr(json, "read"):
@@ -663,7 +665,7 @@ class Disassembler(object):
         """
 
         bank_id = original_offset / 0x4000
-        if debug: print "bank id is: " + str(bank_id)
+        if debug: print("bank id is: " + str(bank_id))
 
         last_hl_address = None #for when we're scanning the main map script
         last_a_address = None
@@ -995,4 +997,4 @@ if __name__ == "__main__":
     else:
         output = "Func_{:02x}: ; {:02x} ({:0x}:{:02x})\n".format(addr, addr, addr / 0x4000, addr % 0x4000 + 0x4000)
     output += disasm.output_bank_opcodes(addr)[0]
-    print output
+    print(output)

--- a/pokemontools/vba/autoplayer.py
+++ b/pokemontools/vba/autoplayer.py
@@ -2,12 +2,14 @@
 """
 Programmatic speedrun of Pokémon Crystal
 """
+from __future__ import print_function
+from __future__ import absolute_import
 import os
 
 import pokemontools.configuration as configuration
 
 # bring in the emulator and basic tools
-import vba as _vba
+from . import vba as _vba
 
 def skippable(func):
     """
@@ -394,13 +396,13 @@ class SpeedRunner(Runner):
             self.cry.text_wait()
 
             hp = self.cry.get_enemy_hp()
-            print "enemy hp is: " + str(hp)
+            print("enemy hp is: " + str(hp))
 
             if hp == 0:
-                print "enemy hp is zero, exiting"
+                print("enemy hp is zero, exiting")
                 break
             else:
-                print "enemy hp is: " + str(hp)
+                print("enemy hp is: " + str(hp))
 
             attacks = attacks - 1
 
@@ -417,7 +419,7 @@ class SpeedRunner(Runner):
         # happens.
         self.cry.text_wait(max_wait=30, debug=True)
 
-        print "okay, back in the overworld"
+        print("okay, back in the overworld")
 
         cur_hp = ((self.cry.vba.memory[0xdd01] << 8) | self.cry.vba.memory[0xdd02])
         move_pp = self.cry.vba.memory[0xdcf6] # move 1 pp

--- a/pokemontools/vba/keyboard.py
+++ b/pokemontools/vba/keyboard.py
@@ -3,6 +3,7 @@
 This file constructs a networkx.DiGraph object called graph, which can be used
 to find the shortest path of keypresses on the keyboard to type a word.
 """
+from __future__ import print_function
 
 import os
 import itertools
@@ -44,7 +45,7 @@ def convert_nodes_to_button_press(node1, node2):
     """
     Determines the button necessary to switch from node1 to node2.
     """
-    print "getting button press for state transition: " + node1 + " -> " + node2
+    print("getting button press for state transition: " + node1 + " -> " + node2)
     return graph.get_edge_data(node1, node2)["key"]
 
 def plan_typing(text, current="A"):
@@ -56,7 +57,7 @@ def plan_typing(text, current="A"):
         if target == current:
             buttons.append("a")
         else:
-            print "Finding the shortest path between " + current + " and " + target
+            print("Finding the shortest path between " + current + " and " + target)
             more_buttons = shortest_path(current, target)
             buttons.extend(more_buttons)
             buttons.append("a")

--- a/pokemontools/vba/vba.py
+++ b/pokemontools/vba/vba.py
@@ -2,6 +2,8 @@
 """
 VBA automation
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
@@ -18,7 +20,7 @@ from pokemontools.map_names import (
     map_names,
 )
 
-import keyboard
+from . import keyboard
 
 # just use a default config for now until the globals are removed completely
 import pokemontools.configuration as configuration
@@ -183,9 +185,9 @@ class crystal(object):
             self.vba.write_memory_at(self.registers.sp + 1, value >> 8)
             self.vba.write_memory_at(self.registers.sp, value & 0xFF)
             if list(self.vba.memory[self.registers.sp : self.registers.sp + 2]) != [value & 0xFF, value >> 8]:
-                print "desired memory values: " + str([value & 0xFF, value >> 8] )
-                print "actual memory values: " + str(list(self.vba.memory[self.registers.sp : self.registers.sp + 2]))
-                print "wrong value at " + hex(self.registers.sp) + " expected " + hex(value) + " but got " + hex(self.vba.read_memory_at(self.registers.sp))
+                print("desired memory values: " + str([value & 0xFF, value >> 8] ))
+                print("actual memory values: " + str(list(self.vba.memory[self.registers.sp : self.registers.sp + 2])))
+                print("wrong value at " + hex(self.registers.sp) + " expected " + hex(value) + " but got " + hex(self.vba.read_memory_at(self.registers.sp)))
 
     def get_stack(self):
         """
@@ -426,7 +428,7 @@ class crystal(object):
             address = ((hi << 8) | lo)
 
             if address in range(0xa1b, 0xa46) + range(0xaaf, 0xaf5): #  0xaef:
-                print "pressing, then breaking.. address is: " + str(hex(address))
+                print("pressing, then breaking.. address is: " + str(hex(address)))
 
                 # set CurSFX
                 self.vba.write_memory_at(0xc2bf, 0)
@@ -436,19 +438,19 @@ class crystal(object):
                 # check if CurSFX is SFX_READ_TEXT_2
                 if self.vba.read_memory_at(0xc2bf) == 0x8:
                     if "CANCEL Which" in self.get_text():
-                        print "probably the 'switch pokemon' menu"
+                        print("probably the 'switch pokemon' menu")
                         return
                     else:
-                        print "cursfx is set to SFX_READ_TEXT_2, looping.."
-                        print self.get_text()
+                        print("cursfx is set to SFX_READ_TEXT_2, looping..")
+                        print(self.get_text())
                         return self.text_wait(step_size=step_size, max_wait=max_wait, debug=debug, callback=callback, sfx_limit=sfx_limit)
                 else:
                     if sfx_limit > 0:
                         sfx_limit = sfx_limit - 1
-                        print "decreasing sfx_limit"
+                        print("decreasing sfx_limit")
                     else:
                         # probably the last textbox in a sequence
-                        print "cursfx is not set to SFX_READ_TEXT_2, so: breaking"
+                        print("cursfx is not set to SFX_READ_TEXT_2, so: breaking")
 
                         break
             else:
@@ -456,19 +458,19 @@ class crystal(object):
 
                 # yes/no box or the name selection box
                 if address in range(0xa46, 0xaaf):
-                    print "probably at a yes/no box.. exiting."
+                    print("probably at a yes/no box.. exiting.")
                     break
 
                 # date/time box (day choice)
                 # 0x47ab is the one from the intro, 0x49ab is the one from mom.
                 elif 0x47ab in stack or 0x49ab in stack: # was any([x in stack for x in range(0x46EE, 0x47AB)])
                     if not self.is_in_battle():
-                        print "probably at a date/time box ? exiting."
+                        print("probably at a date/time box ? exiting.")
                         break
 
                 # "How many minutes?" selection box
                 elif 0x4826 in stack:
-                    print "probably at a \"How many minutes?\" box ? exiting."
+                    print("probably at a \"How many minutes?\" box ? exiting.")
                     break
 
                 self.vba.step(count=step_size)
@@ -482,7 +484,7 @@ class crystal(object):
             if callback != None:
                 result = callback()
                 if result == True:
-                    print "callback returned True, exiting"
+                    print("callback returned True, exiting")
                     return
 
             # only useful when debugging. When this is left on, text that
@@ -492,7 +494,7 @@ class crystal(object):
                 max_wait = max_wait - 1
 
         if max_wait == 0:
-            print "max_wait was hit"
+            print("max_wait was hit")
 
     def walk_through_walls_slow(self):
         memory = self.vba.memory
@@ -852,7 +854,7 @@ class crystal(object):
         """
         while limit > 0:
             if self.vba.read_memory_at(0xd438) != 255:
-                print "script is done executing"
+                print("script is done executing")
                 return
             else:
                 self.vba.step()
@@ -861,7 +863,7 @@ class crystal(object):
                 limit = limit - 1
 
         if limit == 0:
-            print "limit ran out"
+            print("limit ran out")
 
     def move(self, cmd):
         """

--- a/pokemontools/wram.py
+++ b/pokemontools/wram.py
@@ -159,7 +159,7 @@ class BSSReader:
                 # rgbasm allows labels without :, but prefer convention
                 label = line[:line.find(':')]
                 if '\\' in label:
-                    raise Exception, line + ' ' + label
+                    raise Exception(line + ' ' + label)
                 if ';' not in label:
                     section_label = {
                         'label': label,

--- a/redtools/analyze_incbins.py
+++ b/redtools/analyze_incbins.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-03
 #purpose: map which addresses are left
@@ -6,11 +8,11 @@ import sys, os
 from copy import copy, deepcopy
 import subprocess
 import json
-from extract_maps import rom, assert_rom, load_rom, calculate_pointer, load_map_pointers, read_all_map_headers, map_headers
-from pokered_dir import pokered_dir
+from .extract_maps import rom, assert_rom, load_rom, calculate_pointer, load_map_pointers, read_all_map_headers, map_headers
+from .pokered_dir import pokered_dir
 
 try:
-    from pretty_map_headers import map_header_pretty_printer, map_name_cleaner
+    from .pretty_map_headers import map_header_pretty_printer, map_name_cleaner
 except Exception:
     pass
 
@@ -183,9 +185,9 @@ def generate_diff_insert(line_number, newline):
         diffcontent = subprocess.check_output(
                 "diff -u {0} {1}".format(os.path.join(pokered_dir, "main.asm"), newfile_filename),
                 shell=True)
-    except AttributeError, exc:
+    except AttributeError as exc:
         raise exc
-    except Exception, exc:
+    except Exception as exc:
         diffcontent = exc.output
 
     os.system("rm " + original_filename)
@@ -197,7 +199,7 @@ def insert_map_header_asm(map_id):
     map = map_headers[map_id]
     line_number = find_incbin_to_replace_for(map["address"])
     if line_number == None: # or map_name_cleaner(map["name"], 0) in "\n".join(line for line in asm):
-        print "i think map id=" + str(map_id) + " has previously been added."
+        print("i think map id=" + str(map_id) + " has previously been added.")
         return #this map has already been added i bet
     newlines = split_incbin_line_into_three(line_number, map["address"], 12 + (11 * len(map["connections"])))
 
@@ -213,8 +215,8 @@ def insert_map_header_asm(map_id):
 
     diff = generate_diff_insert(line_number, newlines)
     
-    print diff
-    print "... Applying diff."
+    print(diff)
+    print("... Applying diff.")
 
     #write the diff to a file
     fh = open("temp.patch", "w")
@@ -236,7 +238,7 @@ def wrapper_insert_map_header_asm(map_id):
 
 def dump_all_remaining_maps():
     for map_id in map_headers:
-        print "Inserting map id=" + str(map_id)
+        print("Inserting map id=" + str(map_id))
         wrapper_insert_map_header_asm(map_id)
 
 def reset_incbins():
@@ -249,7 +251,7 @@ def reset_incbins():
     process_incbins()
 
 def apply_diff(diff, try_fixing=True, do_compile=True):
-    print "... Applying diff."
+    print("... Applying diff.")
 
     #write the diff to a file
     fh = open("temp.patch", "w")
@@ -272,7 +274,7 @@ def apply_diff(diff, try_fixing=True, do_compile=True):
         try:
             subprocess.check_call("cd {0}; make clean; LC_CTYPE=C make".format(pokered_dir), shell=True)
             return True
-        except Exception, exc:
+        except Exception as exc:
             if try_fixing:
                 os.system("mv {0} {1}".format(
                     os.path.join(pokered_dir, "main1.asm"),
@@ -390,7 +392,7 @@ def get_labels_between(start_line_id, end_line_id, bank_id):
             else:
                 local_pointer = hex((address % 0x4000) + 0x4000).replace("0x", "$")
 
-        print line_label + " is at " + hex(address)
+        print(line_label + " is at " + hex(address))
         
         label = {
             "line_number": line_id,
@@ -438,7 +440,7 @@ def scan_for_predefined_labels():
         else:
             end_line_id = len(asm) - 1
 
-        print "bank" + abbreviation + " starts at " + str(start_line_id) + " to " + str(end_line_id)
+        print("bank" + abbreviation + " starts at " + str(start_line_id) + " to " + str(end_line_id))
 
         bank_intervals[bank_id] = {
                                     "start": start_line_id,
@@ -502,6 +504,6 @@ if __name__ == "__main__":
     #dump_all_remaining_maps()
 
     scan_for_predefined_labels()
-    print "Errors:"
-    print label_errors
+    print("Errors:")
+    print(label_errors)
 

--- a/redtools/analyze_texts.py
+++ b/redtools/analyze_texts.py
@@ -1,11 +1,13 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-06
 #analyze texts, how many commands are unknown?
-import extract_maps
-import analyze_incbins #for asm
+from . import extract_maps
+from . import analyze_incbins #for asm
 try:
-    from pretty_map_headers import map_name_cleaner, txt_bytes, spacing, constant_abbreviation_bytes
-except Exception, exc: pass
+    from .pretty_map_headers import map_name_cleaner, txt_bytes, spacing, constant_abbreviation_bytes
+except Exception as exc: pass
 from operator import itemgetter
 import sys
 debug = False #set to True to increase logging output
@@ -31,7 +33,7 @@ def how_many_until(byte, starting):
 
 def print_command_debug_info(command_byte, text_id, text_pointer, map_id):
     if debug:
-        print "byte is " + str(command_byte) + " on text #" + str(text_id) + " at " + hex(text_pointer) + " on map " + str(map_id) + " (" + extract_maps.map_headers[map_id]["name"] + ")"
+        print("byte is " + str(command_byte) + " on text #" + str(text_id) + " at " + hex(text_pointer) + " on map " + str(map_id) + " (" + extract_maps.map_headers[map_id]["name"] + ")")
 
 def add_command_byte_to_totals(byte):
     global totals
@@ -155,7 +157,7 @@ def parse_text_script(text_pointer, text_id, map_id, txfar=False):
 
             #use this to look at the surrounding bytes
             if debug:
-                print "next command is: " + hex(ord(extract_maps.rom[offset])) + " ... we are at command number: " + str(command_counter) + " near " + hex(offset) + " on map_id=" + str(map_id) + " for text_id=" + str(text_id) + " and txfar(recursion)=" + str(txfar)
+                print("next command is: " + hex(ord(extract_maps.rom[offset])) + " ... we are at command number: " + str(command_counter) + " near " + hex(offset) + " on map_id=" + str(map_id) + " for text_id=" + str(text_id) + " and txfar(recursion)=" + str(txfar))
         elif command_byte == 0x7:
             #07 = shift texts 1 row above (2nd line becomes 1st line); address for next text = 2nd line. [07]
             size = 1
@@ -317,7 +319,7 @@ def parse_text_script(text_pointer, text_id, map_id, txfar=False):
             #if len(commands) > 0:
             #   print "Unknown text command " + hex(command_byte) + " at " + hex(offset) + ", script began with " + hex(commands[0]["type"])
             if debug:
-                print "Unknown text command at " + hex(offset) + " - command: " + hex(ord(extract_maps.rom[offset])) + " on map_id=" + str(map_id) + " text_id=" + str(text_id)
+                print("Unknown text command at " + hex(offset) + " - command: " + hex(ord(extract_maps.rom[offset])) + " on map_id=" + str(map_id) + " text_id=" + str(text_id))
             
             #end at the first unknown command
             end = True
@@ -359,7 +361,7 @@ def analyze_texts():
                     if debug:
                         if len(TX_FAR.keys()) > 0:
                             #print "TX_FAR object: " + str(TX_FAR)
-                            print "processing a TX_FAR at " + hex(commands[command_id]["pointer"]) + "... first byte is: " + str(ord(extract_maps.rom[commands[command_id]["pointer"]])) + " .. offset: " + hex(commands[command_id]["pointer"])
+                            print("processing a TX_FAR at " + hex(commands[command_id]["pointer"]) + "... first byte is: " + str(ord(extract_maps.rom[commands[command_id]["pointer"]])) + " .. offset: " + hex(commands[command_id]["pointer"]))
                             ##sys.exit(0)
 
                     commands[command_id]["TX_FAR"] = TX_FAR
@@ -382,7 +384,7 @@ def find_missing_08s(all_texts):
                     if "type" in current_line.keys():
                         if current_line["type"] == 0x8:
                             missing_08s += 1
-                            print "missing $08 on map_id=" + str(map_id) + " text_id=" + str(text_id) + " line_id=" + str(line_id) + " at " + hex(current_line["start_address"])
+                            print("missing $08 on map_id=" + str(map_id) + " text_id=" + str(text_id) + " line_id=" + str(line_id) + " at " + hex(current_line["start_address"]))
     return missing_08s
 
 def text_pretty_printer_at(start_address, label="SomeLabel"):
@@ -412,7 +414,7 @@ def text_pretty_printer_at(start_address, label="SomeLabel"):
         if not "lines" in commands[this_command].keys():
             command = commands[this_command]
             if not "type" in command.keys():
-                print "ERROR in command: " + str(command)
+                print("ERROR in command: " + str(command))
                 continue #dunno what to do here?
 
             if   command["type"] == 0x1: #TX_RAM
@@ -501,7 +503,7 @@ def text_pretty_printer_at(start_address, label="SomeLabel"):
                 byte_count += 1
                 had_db_last = True
             else:
-                print "ERROR in command: " + hex(command["type"])
+                print("ERROR in command: " + hex(command["type"]))
                 had_db_last = False
 
             #everything else is for $0s, really
@@ -585,7 +587,7 @@ def text_pretty_printer_at(start_address, label="SomeLabel"):
     if len(output)!=0 and output[-1] == "\n":
         include_newline = ""
     output += include_newline + "; " + hex(start_address) + " + " + str(byte_count) + " bytes = " + hex(start_address + byte_count)
-    print output
+    print(output)
     return (output, byte_count)
 
 def is_label_in_asm(label):
@@ -619,16 +621,16 @@ def find_undone_texts():
                 address = extract_maps.map_headers[map_id]["texts"][text_id][1]["start_address"]
             
             if not is_label_in_asm(label):
-                print label + " map_id=" + str(map_id) + " text_id=" + str(text_id) + " at " + hex(address) + " byte is: " + hex(ord(extract_maps.rom[address]))
+                print(label + " map_id=" + str(map_id) + " text_id=" + str(text_id) + " at " + hex(address) + " byte is: " + hex(ord(extract_maps.rom[address])))
                 if not address in usable_table.keys():
                     usable_table[address] = 1
                 else:
                     usable_table[address] += 1
 
-    print "\n\n which ones are priority?"
+    print("\n\n which ones are priority?")
     sorted_results =  sorted(usable_table.iteritems(), key=itemgetter(1), reverse=True)
     for result in sorted_results:
-        print str(result[1]) + " times: " + hex(result[0])
+        print(str(result[1]) + " times: " + hex(result[0]))
 
 def scan_rom_for_tx_fars(printer=True):
     """find TX_FARs
@@ -675,14 +677,14 @@ def scan_rom_for_tx_fars(printer=True):
             if address_bundle[0] in pre_handled:
                 continue #already did this
     
-            print "-------"
-            print "TX_FAR is at: " + hex(address_bundle[1])
+            print("-------")
+            print("TX_FAR is at: " + hex(address_bundle[1]))
             
             #let's try printing out the TX_FAR?
             text_pretty_printer_at(address_bundle[1], "blah")
 
             text_pretty_printer_at(address_bundle[0], "_blah")
-            print "-------"
+            print("-------")
             pre_handled.append(address_bundle[0])
     return possible_tx_far_targets
 

--- a/redtools/connection_helper.py
+++ b/redtools/connection_helper.py
@@ -1,8 +1,10 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-15
 #help with connection math
-import extract_maps
-from pretty_map_headers import map_constants, map_name_cleaner, offset_to_pointer
+from . import extract_maps
+from .pretty_map_headers import map_constants, map_name_cleaner, offset_to_pointer
 
 def print_connections(map_id, in_connection_id=None, do_output=False):
     map1        = extract_maps.map_headers[map_id]
@@ -101,4 +103,4 @@ if __name__ == "__main__":
     
     for map_id in extract_maps.map_headers.keys():
         if map_id not in extract_maps.bad_maps:
-            print print_connections(map_id, do_output=True)
+            print(print_connections(map_id, do_output=True))

--- a/redtools/extract_tileblocks.py
+++ b/redtools/extract_tileblocks.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-14
 #split out blocksets into binary data files
@@ -5,7 +7,7 @@
 # but it's too many lines and will probably crash rgbasm.
 
 import sys
-import extract_maps
+from . import extract_maps
 extract_maps.load_rom()
 spacing = "	"
 
@@ -77,7 +79,7 @@ for tileblock_id in tileblocks.keys():
     fh.write(main_data)
     fh.close()
 
-    print output
+    print(output)
 
 """
 Tset00_Block:

--- a/redtools/extract_tilesets.py
+++ b/redtools/extract_tilesets.py
@@ -1,7 +1,9 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-14
 #throw tilesets into separate files
-import extract_maps
+from . import extract_maps
 extract_maps.load_rom()
 
 locations = {
@@ -29,9 +31,9 @@ locations = {
 for tileset_id in locations.keys():
     tileset = locations[tileset_id]
 
-    print "writing ../gfx/tilesets/" + tileset[2] + ".2bpp"
+    print("writing ../gfx/tilesets/" + tileset[2] + ".2bpp")
     fh = open("../gfx/tilesets/" + tileset[2] + ".2bpp", "w")
     fh.write(extract_maps.rom[tileset[0]:tileset[1]])
     fh.close()
 
-print "Done."
+print("Done.")

--- a/redtools/fix_labels.py
+++ b/redtools/fix_labels.py
@@ -1,12 +1,14 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-27
 #fix trainer header labels to not suck so much
-import analyze_incbins
+from . import analyze_incbins
 
 def replace_trainer_header_labels(debug=False):
     """trainer header labels could be better"""
     asm = analyze_incbins.asm
-    if debug: print str(type(asm))
+    if debug: print(str(type(asm)))
     single_asm = "\n".join(asm)
     current_map_name = "asdjkl;"
     line_id = 0
@@ -31,8 +33,8 @@ def replace_trainer_header_labels(debug=False):
             new_label = current_map_name + "TH" + str(trainer_header_counter) #trainer_header_name
             single_asm = single_asm.replace(old_label + ":", new_label + ":")
             single_asm = single_asm.replace(old_label + "\n", new_label + "\n")
-            if debug: print "old_label = " + old_label
-            if debug: print "new_label = " + new_label
+            if debug: print("old_label = " + old_label)
+            if debug: print("new_label = " + new_label)
 
             trainer_header_counter += 1
         
@@ -50,8 +52,8 @@ def replace_trainer_header_labels(debug=False):
             single_asm = single_asm.replace(old_label + ":", new_label + ":")
             single_asm = single_asm.replace(old_label + "\n", new_label + "\n")
             single_asm = single_asm.replace(old_label + " ;", new_label + " ;")
-            if debug: print "old_label = " + old_label
-            if debug: print "new_label = " + new_label
+            if debug: print("old_label = " + old_label)
+            if debug: print("new_label = " + new_label)
         #replace a text label
         elif " TextAfterBattle" in line and not current_map_name in line:
             old_label = line.split("dw ")[1].split(" ;")[0]
@@ -59,8 +61,8 @@ def replace_trainer_header_labels(debug=False):
             single_asm = single_asm.replace(old_label + ":", new_label + ":")
             single_asm = single_asm.replace(old_label + "\n", new_label + "\n")
             single_asm = single_asm.replace(old_label + " ;", new_label + " ;")
-            if debug: print "old_label = " + old_label
-            if debug: print "new_label = " + new_label
+            if debug: print("old_label = " + old_label)
+            if debug: print("new_label = " + new_label)
         #replace a text label
         elif " TextEndBattle" in line and not current_map_name in line:
             old_label = line.split("dw ")[1].split(" ;")[0]
@@ -68,12 +70,12 @@ def replace_trainer_header_labels(debug=False):
             single_asm = single_asm.replace(old_label + ":", new_label + ":")
             single_asm = single_asm.replace(old_label + "\n", new_label + "\n")
             single_asm = single_asm.replace(old_label + " ;", new_label + " ;")
-            if debug: print "old_label = " + old_label
-            if debug: print "new_label = " + new_label
+            if debug: print("old_label = " + old_label)
+            if debug: print("new_label = " + new_label)
 
         line_id += 1
 
-    print single_asm
+    print(single_asm)
 
 if __name__ == "__main__":
     analyze_incbins.load_asm()

--- a/redtools/gbz80disasm.py
+++ b/redtools/gbz80disasm.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-09
-import extract_maps
+from . import extract_maps
 import os
 import json
 from copy import copy, deepcopy
-from pretty_map_headers import random_hash, map_name_cleaner
+from .pretty_map_headers import random_hash, map_name_cleaner
 from ctypes import c_int8
 import sys
 
@@ -530,7 +532,7 @@ temp_opt_table = [
 conflict_table = {}
 for line in temp_opt_table:
     if line[1] in conflict_table.keys():
-        print "CONFLICT: " + line[0] + " ($" + hex(line[1])[2:] + ") .... " + conflict_table[line[1]]
+        print("CONFLICT: " + line[0] + " ($" + hex(line[1])[2:] + ") .... " + conflict_table[line[1]])
     else:
         conflict_table[line[1]] = line[0]
 
@@ -562,8 +564,8 @@ def load_labels(filename="labels.json"):
     if os.path.exists(filename):
         all_labels = json.loads(open(filename, "r").read())
     else:
-        print "You must run analyze_incbins.scan_for_predefined_labels() to create \"labels.json\". Trying..."
-        import analyze_incbins
+        print("You must run analyze_incbins.scan_for_predefined_labels() to create \"labels.json\". Trying...")
+        from . import analyze_incbins
         analyze_incbins.scan_for_predefined_labels()
 load_labels()
 
@@ -607,7 +609,7 @@ def output_bank_opcodes(original_offset, max_byte_count=0x4000):
     bank_id = 0
     if original_offset > 0x8000:
         bank_id = original_offset / 0x4000
-    print "bank id is: " + str(bank_id)
+    print("bank id is: " + str(bank_id))
 
     last_hl_address = None #for when we're scanning the main map script
     last_a_address = None
@@ -849,4 +851,4 @@ if __name__ == "__main__":
     extract_maps.load_map_pointers()
     extract_maps.read_all_map_headers()
 
-    print output_bank_opcodes(int(sys.argv[1], 16))[0]
+    print(output_bank_opcodes(int(sys.argv[1], 16))[0])

--- a/redtools/generate_sys.py
+++ b/redtools/generate_sys.py
@@ -1,6 +1,7 @@
+from __future__ import absolute_import
 import json
 
-import analyze_incbins
+from . import analyze_incbins
 analyze_incbins.scan_for_predefined_labels()
 
 with open('../pokered.sym', 'w') as sym:

--- a/redtools/insert_object_data.py
+++ b/redtools/insert_object_data.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-05
 #insert object data into pokered.asm
-import extract_maps
-from pretty_map_headers import map_name_cleaner, object_data_pretty_printer, make_object_label_name, make_text_label, map_constants
-from analyze_incbins import asm, offset_to_pointer, find_incbin_to_replace_for, split_incbin_line_into_three, generate_diff_insert, load_asm, isolate_incbins, process_incbins
-import analyze_incbins
+from . import extract_maps
+from .pretty_map_headers import map_name_cleaner, object_data_pretty_printer, make_object_label_name, make_text_label, map_constants
+from .analyze_incbins import asm, offset_to_pointer, find_incbin_to_replace_for, split_incbin_line_into_three, generate_diff_insert, load_asm, isolate_incbins, process_incbins
+from . import analyze_incbins
 import os, sys
 import subprocess
 spacing = "	"
@@ -17,7 +19,7 @@ def insert_object(map_id):
 
     line_number = find_incbin_to_replace_for(address)
     if line_number == None:
-        print "skipping object data for map " + str(map["id"]) + " at " + map["object_data_pointer"] + " for " + str(size) + " bytes."
+        print("skipping object data for map " + str(map["id"]) + " at " + map["object_data_pointer"] + " for " + str(size) + " bytes.")
         return
 
     newlines = split_incbin_line_into_three(line_number, address, size)
@@ -36,9 +38,9 @@ def insert_object(map_id):
     newlines = "\n".join(line for line in newlines)
 
     diff = generate_diff_insert(line_number, newlines)
-    print diff
+    print(diff)
 
-    print "... Applying diff."
+    print("... Applying diff.")
 
     #write the diff to a file
     fh = open("temp.patch", "w")

--- a/redtools/insert_texts.py
+++ b/redtools/insert_texts.py
@@ -1,14 +1,16 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-07, 2012-01-17, 2012-01-27
 #insert TX_FAR targets into pokered.asm
 #and other insertion tasks
-import extract_maps
-from analyze_texts import analyze_texts, text_pretty_printer_at, scan_rom_for_tx_fars
-from pretty_map_headers import map_name_cleaner, make_text_label, map_constants, find_all_tx_fars, tx_far_pretty_printer, tx_far_label_maker
-import pretty_map_headers
-from analyze_incbins import asm, offset_to_pointer, find_incbin_to_replace_for, split_incbin_line_into_three, generate_diff_insert, load_asm, isolate_incbins, process_incbins, reset_incbins, apply_diff
-import analyze_incbins
-from gbz80disasm import text_asm_pretty_printer, output_bank_opcodes, load_labels, find_label
+from . import extract_maps
+from .analyze_texts import analyze_texts, text_pretty_printer_at, scan_rom_for_tx_fars
+from .pretty_map_headers import map_name_cleaner, make_text_label, map_constants, find_all_tx_fars, tx_far_pretty_printer, tx_far_label_maker
+from . import pretty_map_headers
+from .analyze_incbins import asm, offset_to_pointer, find_incbin_to_replace_for, split_incbin_line_into_three, generate_diff_insert, load_asm, isolate_incbins, process_incbins, reset_incbins, apply_diff
+from . import analyze_incbins
+from .gbz80disasm import text_asm_pretty_printer, output_bank_opcodes, load_labels, find_label
 import os, sys
 import subprocess
 spacing = "	"
@@ -66,13 +68,13 @@ def insert_tx_far(map_id, text_id, tx_far_line=None):
 
     line_number = find_incbin_to_replace_for(start_address)
     if line_number == None:
-        print "skipping tx_far for map_id=" + str(map_id) + " text_id=" + str(text_id) + " text_pointer=" + hex(text_pointer) + " tx_far_start_address=" + hex(start_address)
+        print("skipping tx_far for map_id=" + str(map_id) + " text_id=" + str(text_id) + " text_pointer=" + hex(text_pointer) + " tx_far_start_address=" + hex(start_address))
         return
 
     #also do a name check
     label = tx_far_label_maker(extract_maps.map_headers[map_id]["name"], text_id)
     if (label + ":") in "\n".join(analyze_incbins.asm):
-        print "skipping tx_far for map_id=" + str(map_id) + " text_id=" + str(text_id) + " text_pointer=" + hex(text_pointer) + " tx_far_start_address=" + hex(start_address)
+        print("skipping tx_far for map_id=" + str(map_id) + " text_id=" + str(text_id) + " text_pointer=" + hex(text_pointer) + " tx_far_start_address=" + hex(start_address))
         return
     
     newlines = split_incbin_line_into_three(line_number, start_address, end_address - start_address)
@@ -105,8 +107,8 @@ def insert_tx_far(map_id, text_id, tx_far_line=None):
     newlines = newlines.replace("Char52", "$52")
 
     diff = generate_diff_insert(line_number, newlines)
-    print "working on map_id=" + str(map_id) + " text_id=" + str(text_id)
-    print diff
+    print("working on map_id=" + str(map_id) + " text_id=" + str(text_id))
+    print(diff)
     apply_diff(diff)
 
 def insert_all_tx_far_targets():
@@ -184,12 +186,12 @@ def insert_texts_label(map_id):
 
     line_number = find_incbin_to_replace_for(texts_pointer)
     if line_number == None:
-        print "skipping texts label for map_id=" + str(map_id) + " texts_pointer=" + hex(texts_pointer) + " because the address is taken"
+        print("skipping texts label for map_id=" + str(map_id) + " texts_pointer=" + hex(texts_pointer) + " because the address is taken")
         return
 
     #also do a name check
     if (label + ":") in "\n".join(analyze_incbins.asm):
-        print "skipping texts label for map_id=" + str(map_id) + " texts_pointer=" + hex(texts_pointer) + " because the label is already used"
+        print("skipping texts label for map_id=" + str(map_id) + " texts_pointer=" + hex(texts_pointer) + " because the label is already used")
         return
     
     newlines = split_incbin_line_into_three(line_number, texts_pointer, len(map2["referenced_texts"])*2 )
@@ -208,8 +210,8 @@ def insert_texts_label(map_id):
     newlines = newlines.replace("$x", "$")
 
     diff = generate_diff_insert(line_number, newlines)
-    print "working on map_id=" + str(map_id) + " texts_pointer=" + hex(texts_pointer)
-    print diff
+    print("working on map_id=" + str(map_id) + " texts_pointer=" + hex(texts_pointer))
+    print(diff)
     apply_diff(diff)
 
 #untested as of 2012-01-07
@@ -241,7 +243,7 @@ def txt_to_tx_far_pretty_printer(address, label, target_label, include_byte=Fals
 
 def insert_text_label_tx_far(map_id, text_id):
     if map_id in extract_maps.bad_maps:
-        print "bad map id=" + str(map_id)
+        print("bad map id=" + str(map_id))
         return
     map2 = extract_maps.map_headers[map_id]
     if map2["texts"][text_id] == {0: {}}: return None
@@ -253,7 +255,7 @@ def insert_text_label_tx_far(map_id, text_id):
     if 0x4000 <= start_address <= 0x7fff:
         start_address = extract_maps.calculate_pointer(start_address, int(map2["bank"],16))
     include_byte = False
-    print map2["texts"][text_id]
+    print(map2["texts"][text_id])
     if "type" in map2["texts"][text_id][1].keys():
         if map2["texts"][text_id][1]["type"] == 0x50:
             include_byte = True
@@ -261,12 +263,12 @@ def insert_text_label_tx_far(map_id, text_id):
     
     line_number = find_incbin_to_replace_for(start_address)
     if line_number == None:
-        print "skipping text label that calls TX_FAR for map_id=" + str(map_id) + " text_id=" + str(text_id) + " because the address is taken " + hex(start_address)
+        print("skipping text label that calls TX_FAR for map_id=" + str(map_id) + " text_id=" + str(text_id) + " because the address is taken " + hex(start_address))
         return
 
     #also do a name check
     if 1 < ("\n".join(analyze_incbins.asm)).count("\n" + label + ":"):
-        print "skipping text label that calls TX_FAR for map_id=" + str(map_id) + " text_id" + str(text_id) + " because the label is already used (" + label + ":)"
+        print("skipping text label that calls TX_FAR for map_id=" + str(map_id) + " text_id" + str(text_id) + " because the label is already used (" + label + ":)")
         return
     
     extra = 0
@@ -288,8 +290,8 @@ def insert_text_label_tx_far(map_id, text_id):
     newlines = newlines.replace("$x", "$")
 
     diff = generate_diff_insert(line_number, newlines)
-    print "working on map_id=" + str(map_id) + " text_id=" + str(text_id)
-    print diff
+    print("working on map_id=" + str(map_id) + " text_id=" + str(text_id))
+    print(diff)
     apply_diff(diff)
 
 def insert_all_text_labels():
@@ -321,17 +323,17 @@ def insert_08_asm(map_id, text_id, line_id=0):
     start_address = all_texts[map_id][text_id][line_id]["start_address"]
 
     (text_asm, end_address) = text_asm_pretty_printer(label, start_address)
-    print "end address is: " + hex(end_address)
+    print("end address is: " + hex(end_address))
 
     #find where to insert the assembly
     line_number = find_incbin_to_replace_for(start_address)
     if line_number == None:
-        print "skipping text label for a $08 on map_id=" + str(map_id) + " text_id=" + str(text_id) + " because the address is taken"
+        print("skipping text label for a $08 on map_id=" + str(map_id) + " text_id=" + str(text_id) + " because the address is taken")
         return
 
     #also do a name check
     if 1 <= ("\n".join(analyze_incbins.asm)).count("\n" + label + ":"):
-        print "skipping text label for a $08 on map_id=" + str(map_id) + " text_id=" + str(text_id) + " because the label is already taken (" + label + ":)"
+        print("skipping text label for a $08 on map_id=" + str(map_id) + " text_id=" + str(text_id) + " because the label is already taken (" + label + ":)")
         return
     
     newlines = split_incbin_line_into_three(line_number, start_address, end_address - start_address )
@@ -351,8 +353,8 @@ def insert_08_asm(map_id, text_id, line_id=0):
     newlines = newlines.replace("$x", "$")
 
     diff = generate_diff_insert(line_number, newlines)
-    print "working on map_id=" + str(map_id) + " text_id=" + str(text_id)
-    print diff
+    print("working on map_id=" + str(map_id) + " text_id=" + str(text_id))
+    print(diff)
     result = apply_diff(diff)
 
     if result == False:
@@ -376,7 +378,7 @@ def insert_all_08s():
         text_id = the_08_line[1]
         line_id = the_08_line[2]
 
-        print "processing map_id=" + str(map_id) + " text_id=" + str(text_id)
+        print("processing map_id=" + str(map_id) + " text_id=" + str(text_id))
         insert_08_asm(map_id, text_id, line_id)
         
         #reset everything
@@ -396,17 +398,17 @@ def insert_all_08s():
 def insert_asm(start_address, label, text_asm=None, end_address=None):
     if text_asm == None and end_address == None:
         (text_asm, end_address) = text_asm_pretty_printer(label, start_address, include_08=False)
-        print "end address is: " + hex(end_address)
+        print("end address is: " + hex(end_address))
 
     #find where to insert the assembly
     line_number = find_incbin_to_replace_for(start_address)
     if line_number == None:
-        print "skipping asm because the address is taken"
+        print("skipping asm because the address is taken")
         return False
 
     #name check
     if (label + ":") in "\n".join(analyze_incbins.asm):
-        print "skipping asm because the label is taken"
+        print("skipping asm because the label is taken")
         return False
 
     newlines = split_incbin_line_into_three(line_number, start_address, end_address - start_address )
@@ -426,7 +428,7 @@ def insert_asm(start_address, label, text_asm=None, end_address=None):
     newlines = newlines.replace("$x", "$")
 
     diff = generate_diff_insert(line_number, newlines)
-    print diff
+    print(diff)
     result = apply_diff(diff, try_fixing=True)
     return True
 
@@ -436,13 +438,13 @@ def insert_text(address, label, apply=False, try_fixing=True):
 
     line_number = find_incbin_to_replace_for(start_address)
     if line_number == None:
-        print "skipping text at " + hex(start_address) + " with address " + label
+        print("skipping text at " + hex(start_address) + " with address " + label)
         return "skip"
 
     #another reason to skip is if the interval is 0
     processed_incbin = analyze_incbins.processed_incbins[line_number]
     if processed_incbin["interval"] == 0:
-        print "skipping text at " + hex(start_address) + " with address " + label + " because the interval is 0"
+        print("skipping text at " + hex(start_address) + " with address " + label + " because the interval is 0")
         return "skip"
 
     text_asm, byte_count = text_pretty_printer_at(start_address, label)
@@ -466,7 +468,7 @@ def insert_text(address, label, apply=False, try_fixing=True):
     newlines = newlines.replace("Char52", "$52")
 
     diff = generate_diff_insert(line_number, newlines)
-    print diff
+    print(diff)
     if apply:
         return apply_diff(diff, try_fixing=try_fixing)
     else: #simulate a successful insertion
@@ -560,16 +562,16 @@ def scan_for_map_scripts_pointer():
                     isolate_incbins()
                     process_incbins()
 
-            print "map_id=" + str(map_id) + " scripts are: " + str(script_pointers)
+            print("map_id=" + str(map_id) + " scripts are: " + str(script_pointers))
         
         if last_hl_address == None: last_hl_address = "None"
         else: last_hl_address = hex(last_hl_address)
 
         if hl_pointer != None and hl_pointer != "None": hl_pointer = hex(hl_pointer)
 
-        print "map_id=" + str(map_id) + " " + map2["name"] + " script_pointer=" + hex(script_pointer) + " script_pointers=" + hl_pointer + first_script_text
-        print main_asm_output
-        print "\n\n"
+        print("map_id=" + str(map_id) + " " + map2["name"] + " script_pointer=" + hex(script_pointer) + " script_pointers=" + hl_pointer + first_script_text)
+        print(main_asm_output)
+        print("\n\n")
 
         #insert asm for the main script
         result = insert_asm(script_pointer, map_name_cleaner(map2["name"], None)[:-2] + "Script")
@@ -625,8 +627,8 @@ def scan_for_map_scripts_pointer():
                 isolate_incbins()
                 process_incbins()
             else:
-                print "trouble inserting map script pointer list"
-                print script_asm
+                print("trouble inserting map script pointer list")
+                print(script_asm)
                 sys.exit(0)
 
 def scan_rom_for_tx_fars_and_insert():
@@ -647,7 +649,7 @@ def scan_rom_for_tx_fars_and_insert():
 
         #let's also do a quick check if it might be in the file already
         if not (": ; " + hex(tx_far_address) in analyze_incbins.asm):
-            print "inserting text at " + hex(tx_far_address)
+            print("inserting text at " + hex(tx_far_address))
             result = insert_text(tx_far_target_address, tx_far_target_label, apply=True)
         else:
             #we can't just pretend like it worked, because we don't know what label was used
@@ -662,7 +664,7 @@ def scan_rom_for_tx_fars_and_insert():
             result2 = insert_text(tx_far_address, tx_far_label, apply=True)
             local_reset_incbins()
         elif result == "skip":
-            print "skipping " + hex(tx_far_address)
+            print("skipping " + hex(tx_far_address))
         #    result2 = insert_text(tx_far_address, tx_far_label, apply=True)
         #    local_reset_incbins()
 
@@ -787,12 +789,12 @@ def insert_base_stats(id):
     line_number = find_incbin_to_replace_for(address)
     label = get_mon_name(id).title() + "BaseStats"
     if line_number == None:
-        print "skipping, already inserted at " + hex(address)
+        print("skipping, already inserted at " + hex(address))
         return
 
     #also do a name check
     if (label + ":") in "\n".join(analyze_incbins.asm):
-        print "skipping " + label + " because it is already in use.."
+        print("skipping " + label + " because it is already in use..")
         return
     
     newlines = split_incbin_line_into_three(line_number, address, 28 )
@@ -811,7 +813,7 @@ def insert_base_stats(id):
     newlines = newlines.replace("$x", "$")
 
     diff = generate_diff_insert(line_number, newlines)
-    print diff
+    print(diff)
     apply_diff(diff, try_fixing=False, do_compile=False)
 
 def insert_all_base_stats():

--- a/redtools/make_map_size_constants.py
+++ b/redtools/make_map_size_constants.py
@@ -1,8 +1,10 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-15
 #dump map height/width constants
-import extract_maps
-from pretty_map_headers import map_name_cleaner, map_constants
+from . import extract_maps
+from .pretty_map_headers import map_name_cleaner, map_constants
 
 def get_map_size_constants(do_sed=False):
     output = ""
@@ -34,4 +36,4 @@ if __name__ == "__main__":
     extract_maps.load_rom()
     extract_maps.load_map_pointers()
     extract_maps.read_all_map_headers()
-    print get_map_size_constants(do_sed=True)
+    print(get_map_size_constants(do_sed=True))

--- a/redtools/map_block_dumper.py
+++ b/redtools/map_block_dumper.py
@@ -1,11 +1,13 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-03
 #purpose: extract .blk files from baserom.gbc
 #note: use python2.7 because of subprocess in analyze_incbins
-import extract_maps #rom, assert_rom, load_rom, calculate_pointer, load_map_pointers, read_all_map_headers, map_headers
-from pretty_map_headers import map_name_cleaner
-from analyze_incbins import asm, offset_to_pointer, find_incbin_to_replace_for, split_incbin_line_into_three, generate_diff_insert, load_asm, isolate_incbins, process_incbins
-import analyze_incbins
+from . import extract_maps #rom, assert_rom, load_rom, calculate_pointer, load_map_pointers, read_all_map_headers, map_headers
+from .pretty_map_headers import map_name_cleaner
+from .analyze_incbins import asm, offset_to_pointer, find_incbin_to_replace_for, split_incbin_line_into_three, generate_diff_insert, load_asm, isolate_incbins, process_incbins
+from . import analyze_incbins
 import os, sys
 import subprocess
 spacing = "	"
@@ -32,7 +34,7 @@ def extract_map_block_data(map_id, savefile=False):
     full_filepath = "maps/" + filename + ".blk"
 
     if savefile:
-        print "Saving ../maps/" + filename + ".blk for map id=" + str(map_id)
+        print("Saving ../maps/" + filename + ".blk for map id=" + str(map_id))
         fh = open("../maps/" + filename + ".blk", "w")
         fh.write(blocksdata)
         fh.close()
@@ -61,12 +63,12 @@ def insert_map_block_label(map_id):
     x = int(map["x"], 16)
     size = x*y
 
-    print "map name: " + map["name"]
-    print "map address: " + map["map_pointer"]
+    print("map name: " + map["name"])
+    print("map address: " + map["map_pointer"])
 
     line_number = find_incbin_to_replace_for(address)
     if line_number == None:
-        print "skipping map id=" + str(map_id) + " probably because it was already done."
+        print("skipping map id=" + str(map_id) + " probably because it was already done.")
         used_map_pointers.append(map["map_pointer"])
         return
 
@@ -90,8 +92,8 @@ def insert_map_block_label(map_id):
     newlines = newlines.replace("$x", "$")
 
     diff = generate_diff_insert(line_number, newlines)
-    print diff
-    print "... Applying diff."
+    print(diff)
+    print("... Applying diff.")
 
     #write the diff to a file
     fh = open("temp.patch", "w")
@@ -141,14 +143,14 @@ def insert_all_labels():
         #check if this label is already in there
         cleaned_name, label_text, filename, full_filepath = make_labels(mapmap["name"])
         if label_text in "\n".join(line for line in analyze_incbins.asm):
-            print "skipping (found label text in asm already)"
+            print("skipping (found label text in asm already)")
             used_map_pointers.append(mapmap["map_pointer"])
             continue #skip this one
 
         isolate_incbins()
         process_incbins()
         
-        print "XYZ|" + mapmap["name"]
+        print("XYZ|" + mapmap["name"])
         insert_map_block_label(map)
 
         used_map_pointers.append(mapmap["map_pointer"])

--- a/redtools/pretty_map_headers.py
+++ b/redtools/pretty_map_headers.py
@@ -2,12 +2,14 @@
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-02
 #purpose: dump asm for each map header
+from __future__ import print_function
+from __future__ import absolute_import
 import json
-import extract_maps
-import sprite_helper
+from . import extract_maps
+from . import sprite_helper
 import random
 import string
-import analyze_texts #hopefully not a dependency loop
+from . import analyze_texts #hopefully not a dependency loop
 
 base = 16
 spacing = "	"
@@ -395,7 +397,7 @@ def write_connections(north, south, west, east):
     if not north and south and not west and east: return "SOUTH | EAST"
     if north and not south and west and not east: return "NORTH | WEST"
     if north and not south and not west and east: return "NORTH | EAST"
-    raise Exception, "unpredicted outcome on write_connections"
+    raise Exception("unpredicted outcome on write_connections")
 
 #TODO: make this elegant
 def connection_line(byte):
@@ -551,7 +553,7 @@ def object_data_pretty_printer(map_id):
 
         try:
             warp_to_map_constant = map_constants[warp_to_map_id]
-        except Exception, exc:
+        except Exception as exc:
             warp_to_map_constant = "$" + hex(warp_to_map_id)[2:]
 
         output += spacing + "db $" + hex(int(y))[2:] + ", $" + hex(int(x))[2:] + ", $" + hex(int(warp_to_point))[2:] + ", " + warp_to_map_constant + "\n"
@@ -606,7 +608,7 @@ def object_data_pretty_printer(map_id):
             try:
                 previous_location = map_constants[object["warps"][warp_to_id]["warp_to_map_id"]]
                 comment = " ; " + previous_location
-            except Exception, exc:
+            except Exception as exc:
                 comment = ""
 
             output += spacing + "EVENT_DISP $" + map_width[2:] + ", $" + warp_to_y + ", $" + warp_to_x + comment + "\n"
@@ -727,7 +729,7 @@ def print_all_headers():
 
     for map in maps:
         output = map_header_pretty_printer(map)
-        if output != "": print output
+        if output != "": print(output)
 
 if __name__ == "__main__":
     #read binary data from file

--- a/redtools/pretty_text.py
+++ b/redtools/pretty_text.py
@@ -1,14 +1,16 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-16
 from optparse import OptionParser
-from analyze_texts import text_pretty_printer_at
+from .analyze_texts import text_pretty_printer_at
 
 def main():
     usage = "usage: %prog address label"
     parser = OptionParser(usage)
     (options, args) = parser.parse_args()
     if len(args) == 1:
-        print "usage: python pretty_text.py address label"
+        print("usage: python pretty_text.py address label")
         args.append("UnnamedText_" + (args[0].replace("0x", "")))
     elif len(args) != 2:
         parser.error("we need both an address and a label")

--- a/redtools/pretty_trainer_headers.py
+++ b/redtools/pretty_trainer_headers.py
@@ -1,8 +1,10 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-24
 from optparse import OptionParser
-from gbz80disasm import load_labels, find_label
-from extract_maps import calculate_pointer
+from .gbz80disasm import load_labels, find_label
+from .extract_maps import calculate_pointer
 import sys
 spacing = "\t"
 rom = None
@@ -46,8 +48,8 @@ def pretty_print_trainer_header(address, label=None):
     partial_pointer = (pointer_byte1 + (pointer_byte2 << 8))
     label = find_label(partial_pointer, bank_id)
     if label == None:
-        print "label not found for (TextBeforeBattle) " + hex(calculate_pointer(partial_pointer, bank_id))
-        print ""
+        print("label not found for (TextBeforeBattle) " + hex(calculate_pointer(partial_pointer, bank_id)))
+        print("")
         label = "$" + hex(partial_pointer)[2:]
         #sys.exit(0)
 
@@ -59,8 +61,8 @@ def pretty_print_trainer_header(address, label=None):
     partial_pointer = (pointer_byte1 + (pointer_byte2 << 8))
     label = find_label(partial_pointer, bank_id)
     if label == None:
-        print "label not found for (TextAfterBattle) " + hex(calculate_pointer(partial_pointer, bank_id))
-        print ""
+        print("label not found for (TextAfterBattle) " + hex(calculate_pointer(partial_pointer, bank_id)))
+        print("")
         label = "$" + hex(partial_pointer)[2:]
         #sys.exit(0)
 
@@ -72,8 +74,8 @@ def pretty_print_trainer_header(address, label=None):
     partial_pointer = (pointer_byte1 + (pointer_byte2 << 8))
     label = find_label(partial_pointer, bank_id)
     if label == None:
-        print "label not found for (TextEndBattle) " + hex(calculate_pointer(partial_pointer, bank_id))
-        print ""
+        print("label not found for (TextEndBattle) " + hex(calculate_pointer(partial_pointer, bank_id)))
+        print("")
         label = "$" + hex(partial_pointer)[2:]
         #sys.exit(0)
 
@@ -85,8 +87,8 @@ def pretty_print_trainer_header(address, label=None):
     partial_pointer = (pointer_byte1 + (pointer_byte2 << 8))
     label = find_label(partial_pointer, bank_id)
     if label == None:
-        print "label not found for (TextEndBattle) " + hex(calculate_pointer(partial_pointer, bank_id))
-        print ""
+        print("label not found for (TextEndBattle) " + hex(calculate_pointer(partial_pointer, bank_id)))
+        print("")
         label = "$" + hex(partial_pointer)[2:]
         #sys.exit(0)
 
@@ -99,7 +101,7 @@ def pretty_print_trainer_header(address, label=None):
 def all_trainer_headers_at(address):
     i = 0
     while ord(rom[address + (i*12)]) != 0xff:
-        print pretty_print_trainer_header(address + (i*12))
+        print(pretty_print_trainer_header(address + (i*12)))
         i += 1
 
 def main():
@@ -109,7 +111,7 @@ def main():
     parser = OptionParser(usage)
     (options, args) = parser.parse_args()
     if len(args) == 1:
-        print "usage: python pretty_trainer_headers.py address label\n"
+        print("usage: python pretty_trainer_headers.py address label\n")
         args.append("TrainerHeader_" + (args[0].replace("0x", "")))
     elif len(args) != 2:
         parser.error("we need both an address and a label")
@@ -120,7 +122,7 @@ def main():
     rom = open("../baserom.gbc", "r").read()
 
     #print pretty_print_trainer_header(address, label)
-    print all_trainer_headers_at(address)
+    print(all_trainer_headers_at(address))
 
 if __name__ == "__main__":
     main()

--- a/redtools/replace_dimensions.py
+++ b/redtools/replace_dimensions.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-15
 #replace dimensions with constants
 import sys #for non-newline-terminated output :/
-from add_map_labels_to_map_headers import find_with_start_of_line
-from pretty_map_headers import map_name_cleaner, spacing, offset_to_pointer, map_constants
-from connection_helper import print_connections
+from .add_map_labels_to_map_headers import find_with_start_of_line
+from .pretty_map_headers import map_name_cleaner, spacing, offset_to_pointer, map_constants
+from .connection_helper import print_connections
 from ctypes import c_int8
 
 # X/Y_Movement_Of_Connection
@@ -234,7 +235,7 @@ def replace_values():
             connection_offset += 6
 
 if __name__ == "__main__":
-    import extract_maps
+    from . import extract_maps
     extract_maps.load_rom()
     extract_maps.load_map_pointers()
     extract_maps.read_all_map_headers()

--- a/redtools/romvisualizer.py
+++ b/redtools/romvisualizer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-13
 import os
@@ -7,7 +8,7 @@ changeset_numbers = range(1145, 1149)
 def take_snapshot_image(changeset_number):
     "turn main.asm into an image at a certain version"
 
-    print "reverting main.asm to r" + str(changeset_number)
+    print("reverting main.asm to r" + str(changeset_number))
 
     #revert the file (it used to be common.asm)
     os.system("rm ../main.asm; rm ../common.asm; rm ../pokered.asm")
@@ -15,7 +16,7 @@ def take_snapshot_image(changeset_number):
     os.system("hg revert ../common.asm -r" + str(changeset_number))
     os.system("hg revert ../pokered.asm -r" + str(changeset_number))
 
-    print "generating the image.."
+    print("generating the image..")
 
     #draw the image
     os.system("python romviz.py")

--- a/redtools/romviz.py
+++ b/redtools/romviz.py
@@ -1,17 +1,19 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-10
 #show me an image
 import Image
 from math import floor
-import extract_maps
-import analyze_incbins
+from . import extract_maps
+from . import analyze_incbins
 
-print "loading rom.."
+print("loading rom..")
 extract_maps.load_rom()
 #extract_maps.load_map_pointers()
 #extract_maps.read_all_map_headers()
 
-print "analyzing incbins.."
+print("analyzing incbins..")
 analyze_incbins.load_asm()
 analyze_incbins.isolate_incbins()
 analyze_incbins.process_incbins()
@@ -26,7 +28,7 @@ im.putpalette([
     126, 30, 156,
 ])
 
-print "drawing incbins..."
+print("drawing incbins...")
 for incbin_key in analyze_incbins.processed_incbins:
     incbin = analyze_incbins.processed_incbins[incbin_key]
     start = incbin["start"]

--- a/redtools/sprite_helper.py
+++ b/redtools/sprite_helper.py
@@ -1,4 +1,6 @@
-import extract_maps
+from __future__ import print_function
+from __future__ import absolute_import
+from . import extract_maps
 spacing = "\t"
 
 #provided by sawakita
@@ -172,7 +174,7 @@ def load_icons():
             pic = thing["picture_number"]
             unique_icons.add(pic)
     
-            if not icons.has_key(pic): icons[pic] = []
+            if pic not in icons: icons[pic] = []
             
             alerter = None
             if int(thing["y"])-4 > int(map["y"], 16)*2: alerter = True
@@ -199,7 +201,7 @@ def print_appearances():
             output += spacing + ".. in " + appearance[0] + " at (" + str(appearance[1]) + ", " + str(appearance[2]) + ")" + outside_alert + "\n"
         output += "\n"
     
-    print output
+    print(output)
 
 def insert_todo_sprites():
     load_icons()
@@ -251,7 +253,7 @@ def sprite_printer():
         value = hex(key)[2:]
         if len(value) == 1: value = "0" + value
         
-        print sprites[key] + extra + " EQU $" + value
+        print(sprites[key] + extra + " EQU $" + value)
 
 def parse_sprite_sheet_pointer_table():
     """parses the bytes making up the pointer table
@@ -321,7 +323,7 @@ def parse_sprite_sheet_pointer_table():
                 data_entry["byte_count"] += 64
                 setter3 = True
 
-        print ("$%.2x " % (sprite_id)) + sprite_name + " has $%.2x bytes" % (byte_count) + " pointing to 0x%.x" % (pointer) + " bank is $%.2x" % (bank) + " with pose_count=" + str(data_entry["poses"])
+        print(("$%.2x " % (sprite_id)) + sprite_name + " has $%.2x bytes" % (byte_count) + " pointing to 0x%.x" % (pointer) + " bank is $%.2x" % (bank) + " with pose_count=" + str(data_entry["poses"]))
 
         ptable_sheet_data[sprite_id] = data_entry
     return ptable_sheet_data
@@ -398,5 +400,5 @@ if __name__ == "__main__":
     #sprite_printer()
     
     ptable_sheet_data = parse_sprite_sheet_pointer_table()
-    print pretty_print_sheet_incbins(ptable_sheet_data)
-    print pretty_print_sheet_data(ptable_sheet_data)
+    print(pretty_print_sheet_incbins(ptable_sheet_data))
+    print(pretty_print_sheet_data(ptable_sheet_data))

--- a/redtools/text_pointers.py
+++ b/redtools/text_pointers.py
@@ -1,8 +1,10 @@
+from __future__ import print_function
+from __future__ import absolute_import
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-03
 #utilities for working with text pointers
-import extract_maps #rom, assert_rom, load_rom, calculate_pointer, load_map_pointers, read_all_map_headers, map_headers
-from pretty_map_headers import map_name_cleaner
+from . import extract_maps #rom, assert_rom, load_rom, calculate_pointer, load_map_pointers, read_all_map_headers, map_headers
+from .pretty_map_headers import map_name_cleaner
 #import analyze_incbins #asm, offset_to_pointer, find_incbin_to_replace_for, split_incbin_line_into_three, generate_diff_insert, load_asm, isolate_incbins, process_incbins
 spacing = "	"
 
@@ -39,10 +41,10 @@ def test_first_text_pointer_bytes(range=20): #30 for viridian city, 34 for cerul
         first_text_pointer = extract_maps.calculate_pointer(partial_pointer, bank)
 
         #if (first_text_pointer <= (text_list_pointer+range)):
-        print "map " + map["name"] + " (" + str(map["id"]) + ")"
-        print spacing + "text_pointer (list) = " + hex(text_list_pointer)
-        print spacing + "first_text_pointer (first text) = " + hex(first_text_pointer)
-        print spacing + "difference = " + str(first_text_pointer - text_list_pointer)
+        print("map " + map["name"] + " (" + str(map["id"]) + ")")
+        print(spacing + "text_pointer (list) = " + hex(text_list_pointer))
+        print(spacing + "first_text_pointer (first text) = " + hex(first_text_pointer))
+        print(spacing + "difference = " + str(first_text_pointer - text_list_pointer))
         #return False
 
     return True
@@ -52,4 +54,4 @@ if __name__ == "__main__":
     extract_maps.load_map_pointers()
     extract_maps.read_all_map_headers()
 
-    print test_first_text_pointer_bytes()
+    print(test_first_text_pointer_bytes())

--- a/tests/bootstrapping.py
+++ b/tests/bootstrapping.py
@@ -2,7 +2,7 @@
 Functions to bootstrap the emulator state
 """
 
-from setup_vba import (
+from tests.setup_vba import (
     vba,
     autoplayer,
 )

--- a/tests/test_vba.py
+++ b/tests/test_vba.py
@@ -5,13 +5,13 @@ from __future__ import print_function
 
 import unittest
 
-from setup_vba import (
+from tests.setup_vba import (
     vba,
     autoplayer,
     keyboard,
 )
 
-from bootstrapping import (
+from tests.bootstrapping import (
     bootstrap,
     bootstrap_trainer_battle,
 )

--- a/tests/test_vba.py
+++ b/tests/test_vba.py
@@ -1,6 +1,7 @@
 """
 Tests for VBA automation tools
 """
+from __future__ import print_function
 
 import unittest
 
@@ -267,13 +268,13 @@ class VbaTests(unittest.TestCase):
         start_state = self.cry.vba.state
 
         for name in names:
-            print "Writing name: " + name
+            print("Writing name: " + name)
 
             self.cry.vba.state = start_state
 
             sequence = self.cry.write(name)
 
-            print "sequence is: " + str(sequence)
+            print("sequence is: " + str(sequence))
 
             # save this selection
             self.cry.vba.press("start", hold=20)

--- a/tests/test_vba_battle.py
+++ b/tests/test_vba_battle.py
@@ -4,7 +4,7 @@ Tests for the battle controller
 
 import unittest
 
-from setup_vba import (
+from tests.setup_vba import (
     vba,
     autoplayer,
 )


### PR DESCRIPTION
The first commit is entirely automated, using `futurize --stage1` (a subset of `2to3` that avoids doing anything that would break 2).  Looks like it accidentally nuked the CRs from a couple files, which has made this diff look much worse than it actually is.

Successfully builds both pokered and pokeyellow using CPython 2.7 and CPython 3.5 and maybe even a PyPy in there somewhere.  Makes me happy since bare `python` is Python 3 on Arch.

The test suite appears to be on fire, which makes it hard to tell if I broke anything.  May keep poking at this, though.
