### PR TITLE
Make wram.py compatible with the const macro and with UNIONs

### DIFF
--- a/pokemontools/wram.py
+++ b/pokemontools/wram.py
@@ -6,6 +6,7 @@ RGBDS BSS section and constant parsing.
 import os
 import os.path
 
+const_value = 0
 
 def separate_comment(line):
     if ';' in line:
@@ -176,7 +177,18 @@ class BSSReader:
                         real = split_line[index]
                         name, value = map(' '.join, [split_line[:index], split_line[index+1:]])
                         value = rgbasm_to_py(value)
-                        self.constants[name] = eval(value, self.constants.copy())
+                        if value:
+                            global const_value
+                            if name == 'const_value':
+                                if value.startswith('const_value + 1'):
+                                    const_value += 1
+                                else: # const_def
+                                    const_value = eval(value)
+                            else: # name is a symbol
+                                if value.startswith('const_value'):
+                                    self.constants[name] = eval(value)
+                                else:
+                                    self.constants[name] = eval(value, self.constants.copy())
 
             else:
                 self.read_bss_line(line)


### PR DESCRIPTION
Not sure just how much of a hack this will feel because this is my first time actually doing anything in python and I couldn't get the const support to work without the global (because the const_value current value was lost everytime a new macro was parsed, as far as I understood).

Anyway, the goal was to be able to use UNIONs and const while disassembling poketcg without having to use an separate repo or ignore/submit a dirty submodule, so if anyone wants to come up with a less hacky implementation for these two things, that'd be great I guess.

This one requires a ``const_def`` macro with the conditional written like this:

```
const_def: MACRO
IF _NARG == 0
const_value = 0
ELSE
const_value = \1
ENDC
ENDM
```

and also using ``const_def N`` instead of ``const_value set N`` or ``const_value = N``.