### PR TITLE
gbz80disasm: Fix ValueError on some jumps

### DIFF
--- a/pokemontools/gbz80disasm.py
+++ b/pokemontools/gbz80disasm.py
@@ -223,7 +223,7 @@ z80_table = [
 	('rst $8', 0),                 # cf
 	('ret nc', 0),                 # d0
 	('pop de', 0),                 # d1
-	('jp nc, ${:04x}', 2),         # d2
+	('jp nc, {}', 2),              # d2
 	('db $d3', 0),                 # d3
 	('call nc, {}', 2),            # d4
 	('push de', 0),                # d5
@@ -231,7 +231,7 @@ z80_table = [
 	('rst $10', 0),                # d7
 	('ret c', 0),                  # d8
 	('reti', 0),                   # d9
-	('jp c, ${:04x}', 2),          # da
+	('jp c, {}', 2),               # da
 	('db $db', 0),                 # db
 	('call c, {}', 2),             # dc
 	('db $dd', 2),                 # dd


### PR DESCRIPTION
Fix a string (label) being passed to formats that expected a number (address?). I have no idea if this is actually correct, beyond making the exceptions go away...

```
$ python -m pokemontools.gbz80disasm -r baserom-gold.gbc 171d1
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/ryan/src/pokemon-reverse-engineering-tools/pokemontools/gbz80disasm.py", line 905, in <module>
    output = disasm.output_bank_opcodes(start_addr,stop_addr,hard_stop=args.dry_run,parse_data=args.parse_data)[0]
  File "/home/ryan/src/pokemon-reverse-engineering-tools/pokemontools/gbz80disasm.py", line 776, in output_bank_opcodes
    opcode_output_str = opcode_str.format(target_label)	
ValueError: Unknown format code 'x' for object of type 'str'
```
-> contains `jp nc, Func_1726b`
```
$ python -m pokemontools.gbz80disasm -r baserom-gold.gbc 65e7
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/ryan/src/pokemon-reverse-engineering-tools/pokemontools/gbz80disasm.py", line 905, in <module>
    output = disasm.output_bank_opcodes(start_addr,stop_addr,hard_stop=args.dry_run,parse_data=args.parse_data)[0]
  File "/home/ryan/src/pokemon-reverse-engineering-tools/pokemontools/gbz80disasm.py", line 776, in output_bank_opcodes
    opcode_output_str = opcode_str.format(target_label)	
ValueError: Unknown format code 'x' for object of type 'str'
```
-> contains `jp c, Func_6694`