### PR TITLE
Fix all compile-time warnings and errors

### DIFF
--- a/pokemontools/crystal.py
+++ b/pokemontools/crystal.py
@@ -1577,7 +1577,7 @@ def create_movement_commands(debug=False):
         if type(cmd) == str:
             cmd = [cmd]
         cmd_name = cmd[0].replace(" ", "_")
-        params = {"id": byte, "size": 1, "end": byte is 0x47, "macro_name": cmd_name}
+        params = {"id": byte, "size": 1, "end": byte == 0x47, "macro_name": cmd_name}
         params["param_types"] = {}
         if len(cmd) > 1:
             param_types = cmd[1:]

--- a/redtools/extract_maps.py
+++ b/redtools/extract_maps.py
@@ -1,10 +1,9 @@
 #author: Bryan Bishop <kanzure@gmail.com>
 #date: 2012-01-02
 #url: http://hax.iimarck.us/files/rbheaders.txt
+from __future__ import print_function
 import json
 import os
-
-from __future__ import print_function
 
 #parse hex values as base 16 (see calculate_pointer)
 base = 16


### PR DESCRIPTION
in `pokemontools/crystal.py`, there is a syntax warning that shows up upon compile:

```
byte-compiling build/bdist.linux-x86_64/egg/pokemontools/crystal.py to crystal.cpython-38.pyc
build/bdist.linux-x86_64/egg/pokemontools/crystal.py:1580: SyntaxWarning: "is" with a literal. Did you mean "=="?
  params = {"id": byte, "size": 1, "end": byte is 0x47, "macro_name": cmd_name}
```

and in `redtools/extract_maps.py`, there is a syntax error preventing it from compiling:

```
byte-compiling build/bdist.linux-x86_64/egg/redtools/extract_maps.py to extract_maps.cpython-38.pyc
  File "build/bdist.linux-x86_64/egg/redtools/extract_maps.py", line 7
    from __future__ import print_function
    ^
SyntaxError: from __future__ imports must occur at the beginning of the file
```

With these fixes applied, these tools build and install properly now without errors or warnings of any kind